### PR TITLE
Patch report descriptor Pop tag

### DIFF
--- a/HidSharp/Reports/ReportDescriptor.cs
+++ b/HidSharp/Reports/ReportDescriptor.cs
@@ -167,7 +167,7 @@ namespace HidSharp.Reports
                             break;
 
                         case GlobalItemTag.Pop:
-                            State.GlobalItemStateStack.RemoveAt(State.GlobalItemState.Count - 1);
+                            State.GlobalItemStateStack.RemoveAt(State.GlobalItemStateStack.Count - 1);
                             break;
 
                         default:


### PR DESCRIPTION
This fixes the Pop tag which plague XP-Pen tablets. 