### PR TITLE
Add HidDevice.CanOpen

### DIFF
--- a/HidSharp/Device.cs
+++ b/HidSharp/Device.cs
@@ -143,5 +143,7 @@ namespace HidSharp
         {
             get;
         }
+
+        public abstract bool CanOpen { get; }
     }
 }

--- a/HidSharp/Platform/Linux/LinuxHidDevice.cs
+++ b/HidSharp/Platform/Linux/LinuxHidDevice.cs
@@ -325,6 +325,8 @@ namespace HidSharp.Platform.Linux
             get { return _version; }
         }
 
+        public override bool CanOpen => true;
+
         internal bool ReportsUseID
         {
             get { return _reportsUseID; }

--- a/HidSharp/Platform/Linux/LinuxSerialDevice.cs
+++ b/HidSharp/Platform/Linux/LinuxSerialDevice.cs
@@ -47,5 +47,7 @@ namespace HidSharp.Platform.Linux
         {
             get { return _portName; }
         }
+
+        public override bool CanOpen => true;
     }
 }

--- a/HidSharp/Platform/MacOS/MacHidDevice.cs
+++ b/HidSharp/Platform/MacOS/MacHidDevice.cs
@@ -316,6 +316,8 @@ namespace HidSharp.Platform.MacOS
             get { return _version; }
         }
 
+        public override bool CanOpen => true;
+
         internal bool ReportsUseID
         {
             get { return _reportsUseID; }

--- a/HidSharp/Platform/MacOS/MacSerialDevice.cs
+++ b/HidSharp/Platform/MacOS/MacSerialDevice.cs
@@ -59,5 +59,7 @@ namespace HidSharp.Platform.MacOS
         {
             get { return _path.ToString(); }
         }
+
+        public override bool CanOpen => true;
     }
 }

--- a/HidSharp/Platform/Windows/NativeMethods.cs
+++ b/HidSharp/Platform/Windows/NativeMethods.cs
@@ -873,7 +873,11 @@ namespace HidSharp.Platform.Windows
             Unknown2         = 0x2000000  // ???
         }
 
-        public static int[] RestrictedHIDUsage = new int[] { 1, 2, 6, 7 };
+        public static Dictionary<int, List<int>> RestrictedHIDs = new Dictionary<int, List<int>>
+        {
+            [0x01] = { 1, 2, 6, 7 },
+            [0x0D] = { 1, 2, 4, 5 }
+        };
 
         public static IntPtr CreateAutoResetEventOrThrow()
         {

--- a/HidSharp/Platform/Windows/NativeMethods.cs
+++ b/HidSharp/Platform/Windows/NativeMethods.cs
@@ -18,6 +18,8 @@
 #pragma warning disable 169, 649
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
@@ -870,6 +872,8 @@ namespace HidSharp.Platform.Windows
             Unknown1         = 0x1000000, // ???
             Unknown2         = 0x2000000  // ???
         }
+
+        public static int[] RestrictedHIDUsage = new int[] { 1, 2, 6, 7 };
 
         public static IntPtr CreateAutoResetEventOrThrow()
         {

--- a/HidSharp/Platform/Windows/NativeMethods.cs
+++ b/HidSharp/Platform/Windows/NativeMethods.cs
@@ -873,10 +873,10 @@ namespace HidSharp.Platform.Windows
             Unknown2         = 0x2000000  // ???
         }
 
-        public static Dictionary<int, List<int>> RestrictedHIDs = new Dictionary<int, List<int>>
+        public static Dictionary<int, List<int>> RestrictedHIDs = new Dictionary<int, List<int>>()
         {
-            [0x01] = { 1, 2, 6, 7 },
-            [0x0D] = { 1, 2, 4, 5 }
+            { 0x01, new List<int>() { 1, 2, 6, 7 } },
+            { 0x0D, new List<int>() { 1, 2, 4, 5 } }
         };
 
         public static IntPtr CreateAutoResetEventOrThrow()

--- a/HidSharp/Platform/Windows/NativeMethods.cs
+++ b/HidSharp/Platform/Windows/NativeMethods.cs
@@ -873,6 +873,8 @@ namespace HidSharp.Platform.Windows
             Unknown2         = 0x2000000  // ???
         }
 
+        // Reference:
+        //   https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/hid-architecture#hid-clients-supported-in-windows
         public static Dictionary<int, List<int>> RestrictedHIDs = new Dictionary<int, List<int>>()
         {
             { 0x01, new List<int>() { 1, 2, 6, 7 } },

--- a/HidSharp/Platform/Windows/WinBleDevice.cs
+++ b/HidSharp/Platform/Windows/WinBleDevice.cs
@@ -206,5 +206,7 @@ namespace HidSharp.Platform.Windows
         {
             get { return _path; }
         }
+
+        public override bool CanOpen => true;
     }
 }

--- a/HidSharp/Platform/Windows/WinHidDevice.cs
+++ b/HidSharp/Platform/Windows/WinHidDevice.cs
@@ -123,10 +123,7 @@ namespace HidSharp.Platform.Windows
                                 _maxOutput = caps.OutputReportByteLength;
                                 _maxFeature = caps.FeatureReportByteLength;
 
-                                if (caps.UsagePage == 1)
-                                    _canOpen = !NativeMethods.RestrictedHIDUsage.Contains(caps.Usage);
-                                else
-                                    _canOpen = true;
+                                _canOpen = !NativeMethods.RestrictedHIDs.ContainsKey(caps.UsagePage) || NativeMethods.RestrictedHIDs[caps.UsagePage].Contains(caps.Usage);
 
                                 try { _reportDescriptor = new ReportDescriptorReconstructor().Run(preparsed, caps); }
                                 catch (NotImplementedException) { _reportDescriptor = null; }

--- a/HidSharp/Platform/Windows/WinHidDevice.cs
+++ b/HidSharp/Platform/Windows/WinHidDevice.cs
@@ -123,7 +123,7 @@ namespace HidSharp.Platform.Windows
                                 _maxOutput = caps.OutputReportByteLength;
                                 _maxFeature = caps.FeatureReportByteLength;
 
-                                _canOpen = !NativeMethods.RestrictedHIDs.ContainsKey(caps.UsagePage) || NativeMethods.RestrictedHIDs[caps.UsagePage].Contains(caps.Usage);
+                                _canOpen = !(NativeMethods.RestrictedHIDs.ContainsKey(caps.UsagePage) && NativeMethods.RestrictedHIDs[caps.UsagePage].Contains(caps.Usage));
 
                                 try { _reportDescriptor = new ReportDescriptorReconstructor().Run(preparsed, caps); }
                                 catch (NotImplementedException) { _reportDescriptor = null; }

--- a/HidSharp/Platform/Windows/WinSerialDevice.cs
+++ b/HidSharp/Platform/Windows/WinSerialDevice.cs
@@ -49,5 +49,7 @@ namespace HidSharp.Platform.Windows
         {
             get { return _path; }
         }
+
+        public override bool CanOpen => true;
     }
 }


### PR DESCRIPTION
OTD Output: 

[Before](https://github.com/InfinityGhost/HIDSharpCore/files/5579684/before.zip), [After](https://github.com/InfinityGhost/HIDSharpCore/files/5579686/after.zip)

This allows us to know in advance which `HidDevices` are exclusively opened by Windows according to [this article](https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/top-level-collections-opened-by-windows-for-system-use).