### PR TITLE
Remove Digitizer usage with Digitizer usage page on RestrictedHIDs

### DIFF
--- a/HidSharp/Platform/Windows/NativeMethods.cs
+++ b/HidSharp/Platform/Windows/NativeMethods.cs
@@ -878,7 +878,7 @@ namespace HidSharp.Platform.Windows
         public static Dictionary<int, List<int>> RestrictedHIDs = new Dictionary<int, List<int>>()
         {
             { 0x01, new List<int>() { 1, 2, 6, 7 } },
-            { 0x0D, new List<int>() { 1, 2, 4, 5 } }
+            { 0x0D, new List<int>() { 2, 4, 5 } }
         };
 
         public static IntPtr CreateAutoResetEventOrThrow()


### PR DESCRIPTION
Some Wacom report the tablet as a Digitizer with a *Digitizer* usage page. Most UC Logic supporting pnp windows ink reports the tablet as a Digitizer with a *Stylus* usage page.

Windows don't exclusively open the first case since it doesn't have any X, Y, or any pressure capabilities reported for it to be usable in Windows Ink.

We remove the 0x0D-0x01 combination for now from the RestrictedHIDs dictionary as a quick patch.

Closes #16