### PR TITLE
Target .NET 6 LTS

### DIFF
--- a/HidSharp.Test/HidSharp.Test.csproj
+++ b/HidSharp.Test/HidSharp.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>HidSharp.Test</AssemblyName>

--- a/HidSharp/HidSharp.csproj
+++ b/HidSharp/HidSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>HidSharpCore</AssemblyName>


### PR DESCRIPTION
.NET 5 has reached End of life and .NET 6 is a LTS release. This PR upgrades to .NET 6.0.