### PR TITLE
Implement HidDevice.IsSibling()

### DIFF
--- a/HidSharp/HidDevice.cs
+++ b/HidSharp/HidDevice.cs
@@ -151,6 +151,13 @@ namespace HidSharp
         }
 
         /// <summary>
+        /// Determines if the given device and this device are of the same USB device.
+        /// </summary>
+        /// <param name="device">The device to compare with this device.</param>
+        /// <returns>Returns true if the given device and this device are of the same USB device.</returns>
+        public abstract bool IsSibling(HidDevice device);
+
+        /// <summary>
         /// The USB product ID. These are listed at: http://usb-ids.gowdy.us
         /// </summary>
         public abstract int ProductID

--- a/HidSharp/Platform/Linux/LinuxHidDevice.cs
+++ b/HidSharp/Platform/Linux/LinuxHidDevice.cs
@@ -306,7 +306,14 @@ namespace HidSharp.Platform.Linux
         {
             if (device is not LinuxHidDevice linuxDevice) { return false; }
 
-            return GetUsbPath() == linuxDevice.GetUsbPath();
+            try
+            {
+                return GetUsbPath() == linuxDevice.GetUsbPath();
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         public override string DevicePath

--- a/HidSharp/Platform/Linux/LinuxHidDevice.cs
+++ b/HidSharp/Platform/Linux/LinuxHidDevice.cs
@@ -176,75 +176,53 @@ namespace HidSharp.Platform.Linux
                 wLength = 255
             };
 
-            string usbPath;
+            string usbPath = GetUsbPath();
 
-            IntPtr udev = NativeMethodsLibudev.Instance.udev_new();
-            var handle = NativeMethodsLibudev.Instance.udev_device_new_from_syspath(udev, _path);
-
-            IntPtr parent = NativeMethodsLibudev.Instance.udev_device_get_parent_with_subsystem_devtype(handle, "usb", "usb_device");
-
-            string devNum = NativeMethodsLibudev.Instance.udev_device_get_sysattr_value(parent, "devnum");
-            string busNum = NativeMethodsLibudev.Instance.udev_device_get_sysattr_value(parent, "busnum");
-
-            usbPath = $"/dev/bus/usb/{int.Parse(busNum):D3}/{int.Parse(devNum):D3}";
-
-            try
+            fixed (char* sbuf = new char[255])
             {
-                fixed (char* sbuf = new char[255])
+                setup.data = sbuf;
+
+                // Send packet
+                int usbHandle = open(usbPath, oflag.NONBLOCK | oflag.RDWR);
+                if (ioctl(usbHandle, USBDEVFS_CONTROL, ref setup) < 0)
                 {
-                    setup.data = sbuf;
-
-                    // Send packet
-                    int usbHandle = open(usbPath, oflag.NONBLOCK | oflag.RDWR);
-                    if (ioctl(usbHandle, USBDEVFS_CONTROL, ref setup) < 0)
-                    {
-                        close(usbHandle);
-                        var err = (error)Marshal.GetLastWin32Error();
-                        throw new DeviceIOException(this, $"Unable to retrieve device's supported langId: {err}");
-                    }
-
-                    // Retrieve langId
-                    var buf = (byte*)setup.data;
-                    ushort langId = (ushort)(buf[2] | buf[3] << 8);
-
-                    for (int i = 0; i < 255; i++)
-                    {
-                        buf[i] = 0;
-                    }
-
-                    // Retrieve string
-                    setup.wIndex = langId;
-                    setup.wValue = string_index((byte)index);
-                    if (ioctl(usbHandle, USBDEVFS_CONTROL, ref setup) < 0)
-                    {
-                        close(usbHandle);
-                        var err = (error)Marshal.GetLastWin32Error();
-                        throw new DeviceIOException(this, $"Unable to retrieve device string at index {index}: {err}");
-                    }
-
                     close(usbHandle);
-
-                    var deviceString = new StringBuilder(255);
-                    var ssbuf = (char*)setup.data;
-                    for (int i = 1; i < 255; i++)
-                    {
-                        var c = ssbuf[i];
-                        if (c == 0)
-                            break;
-                        else
-                            deviceString.Append(c);
-                    }
-                    return deviceString.ToString();
+                    var err = (error)Marshal.GetLastWin32Error();
+                    throw new DeviceIOException(this, $"Unable to retrieve device's supported langId: {err}");
                 }
-            }
-            catch
-            {
-                throw;
-            }
-            finally
-            {
-                NativeMethodsLibudev.Instance.udev_device_unref(parent);
-                NativeMethodsLibudev.Instance.udev_unref(udev);
+
+                // Retrieve langId
+                var buf = (byte*)setup.data;
+                ushort langId = (ushort)(buf[2] | buf[3] << 8);
+
+                for (int i = 0; i < 255; i++)
+                {
+                    buf[i] = 0;
+                }
+
+                // Retrieve string
+                setup.wIndex = langId;
+                setup.wValue = string_index((byte)index);
+                if (ioctl(usbHandle, USBDEVFS_CONTROL, ref setup) < 0)
+                {
+                    close(usbHandle);
+                    var err = (error)Marshal.GetLastWin32Error();
+                    throw new DeviceIOException(this, $"Unable to retrieve device string at index {index}: {err}");
+                }
+
+                close(usbHandle);
+
+                var deviceString = new StringBuilder(255);
+                var ssbuf = (char*)setup.data;
+                for (int i = 1; i < 255; i++)
+                {
+                    var c = ssbuf[i];
+                    if (c == 0)
+                        break;
+                    else
+                        deviceString.Append(c);
+                }
+                return deviceString.ToString();
             }
         }
 
@@ -295,6 +273,20 @@ namespace HidSharp.Platform.Linux
             }
         }
 
+        unsafe string GetUsbPath()
+        {
+            using (var udev = new SafeUdevHandle(NativeMethodsLibudev.Instance.udev_new()))
+            using (var handle = new SafeUdevDeviceHandle(NativeMethodsLibudev.Instance.udev_device_new_from_syspath(udev.DangerousGetHandle(), _path)))
+            using (var parent = new SafeUdevDeviceHandle(NativeMethodsLibudev.Instance.udev_device_get_parent_with_subsystem_devtype(handle.DangerousGetHandle(), "usb", "usb_device")))
+            {
+                var parentPtr = parent.DangerousGetHandle();
+                string devNum = NativeMethodsLibudev.Instance.udev_device_get_sysattr_value(parentPtr, "devnum");
+                string busNum = NativeMethodsLibudev.Instance.udev_device_get_sysattr_value(parentPtr, "busnum");
+
+                return $"/dev/bus/usb/{int.Parse(busNum):D3}/{int.Parse(devNum):D3}";
+            }
+        }
+
         public override string GetFileSystemName()
         {
             return _fileSystemName;
@@ -303,6 +295,13 @@ namespace HidSharp.Platform.Linux
         public override bool HasImplementationDetail(Guid detail)
         {
             return base.HasImplementationDetail(detail) || detail == ImplementationDetail.Linux || detail == ImplementationDetail.HidrawApi;
+        }
+
+        public override bool IsSibling(HidDevice device)
+        {
+            if (device is not LinuxHidDevice linuxDevice) { return false; }
+
+            return GetUsbPath() == linuxDevice.GetUsbPath();
         }
 
         public override string DevicePath

--- a/HidSharp/Platform/Linux/SafeUdevPtr.cs
+++ b/HidSharp/Platform/Linux/SafeUdevPtr.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace HidSharp.Platform.Linux
+{
+    sealed class SafeUdevHandle : SafeHandle
+    {
+        public SafeUdevHandle()
+            : base(IntPtr.Zero, true)
+        {
+        }
+
+        public SafeUdevHandle(IntPtr handle)
+            : base(IntPtr.Zero, true)
+        {
+            SetHandle(handle);
+        }
+
+        public override bool IsInvalid
+        {
+            get { return IntPtr.Zero == handle; }
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            NativeMethodsLibudev.Instance.udev_unref(handle);
+            return true;
+        }
+    }
+
+    sealed class SafeUdevDeviceHandle : SafeHandle
+    {
+        public SafeUdevDeviceHandle()
+            : base(IntPtr.Zero, true)
+        {
+        }
+
+        public SafeUdevDeviceHandle(IntPtr handle)
+            : base(IntPtr.Zero, true)
+        {
+            SetHandle(handle);
+        }
+
+        public override bool IsInvalid
+        {
+            get { return IntPtr.Zero == handle; }
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            NativeMethodsLibudev.Instance.udev_device_unref(handle);
+            return true;
+        }
+    }
+}

--- a/HidSharp/Platform/MacOS/MacHidDevice.cs
+++ b/HidSharp/Platform/MacOS/MacHidDevice.cs
@@ -278,8 +278,14 @@ namespace HidSharp.Platform.MacOS
         {
             if (device is not MacHidDevice macDevice) { return false; }
 
-            // Check if the devices are siblings by comparing their UsbDeviceIds
-            return GetUsbDeviceId() == macDevice.GetUsbDeviceId();
+            try
+            {
+                return GetUsbDeviceId() == macDevice.GetUsbDeviceId();
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         int GetUsbDeviceId()

--- a/HidSharp/Platform/Windows/WinHidDevice.cs
+++ b/HidSharp/Platform/Windows/WinHidDevice.cs
@@ -324,6 +324,22 @@ namespace HidSharp.Platform.Windows
             return base.HasImplementationDetail(detail) || detail == ImplementationDetail.Windows;
         }
 
+        public override bool IsSibling(HidDevice device)
+        {
+            if (device is not WinHidDevice winDevice)
+            {
+                return false;
+            }
+
+            if (!TryGetDeviceUsbRoot(out uint devInst1)
+                || !winDevice.TryGetDeviceUsbRoot(out uint devInst2))
+            {
+                return false;
+            }
+
+            return devInst1 == devInst2;
+        }
+
         public override string DevicePath
         {
             get { return _path; }

--- a/HidSharp/Platform/Windows/WinHidDevice.cs
+++ b/HidSharp/Platform/Windows/WinHidDevice.cs
@@ -331,13 +331,20 @@ namespace HidSharp.Platform.Windows
                 return false;
             }
 
-            if (!TryGetDeviceUsbRoot(out uint devInst1)
-                || !winDevice.TryGetDeviceUsbRoot(out uint devInst2))
+            try
+            {
+                if (!TryGetDeviceUsbRoot(out uint devInst1)
+                    || !winDevice.TryGetDeviceUsbRoot(out uint devInst2))
+                {
+                    return false;
+                }
+
+                return devInst1 == devInst2;
+            }
+            catch
             {
                 return false;
             }
-
-            return devInst1 == devInst2;
         }
 
         public override string DevicePath


### PR DESCRIPTION
This allows us to determine if two or more USB endpoints belongs to the same USB device. The function is guarded by a try-catch to return false for any HidDevice that isn't actually a USB device.