### PR TITLE
Update to .NET 8 and apply lints

### DIFF
--- a/HidSharp.Test/HidSharp.Test.csproj
+++ b/HidSharp.Test/HidSharp.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>HidSharp.Test</AssemblyName>

--- a/HidSharp.Test/Program.cs
+++ b/HidSharp.Test/Program.cs
@@ -80,122 +80,121 @@ namespace HidSharp.Test
             //Console.WriteLine("Beginning discovery.");
             //using (list.BeginBleDiscovery())
             {
-
-            var allDeviceList = list.GetAllDevices().ToArray();
-            Console.WriteLine("All device list:");
-            foreach (Device dev in allDeviceList)
-            {
-                Console.WriteLine(dev.ToString() + " @ " + dev.DevicePath);
-                /*
-                if (dev is HidDevice)
+                var allDeviceList = list.GetAllDevices().ToArray();
+                Console.WriteLine("All device list:");
+                foreach (Device dev in allDeviceList)
                 {
-                    foreach (var serialPort in
-                        (((HidDevice)dev).GetSerialPorts()))
+                    Console.WriteLine(dev.ToString() + " @ " + dev.DevicePath);
+                    /*
+                    if (dev is HidDevice)
                     {
-                        Console.WriteLine("    " + serialPort);
-                    }
-                }
-                */
-            }
-
-            var bleDeviceList = list.GetBleDevices().ToArray();
-            Console.WriteLine("BLE device list:");
-            foreach (BleDevice dev in bleDeviceList)
-            {
-                Console.WriteLine(dev.ToString() + "@" + dev.DevicePath);
-                foreach (var service in dev.GetServices())
-                {
-                    Console.WriteLine(string.Format("\tService: {0}", service.Uuid));
-                    foreach (var characteristic in service.GetCharacteristics())
-                    {
-                        Console.WriteLine(string.Format("\t\tCharacteristic: {0} (Properties: {1})", characteristic.Uuid, characteristic.Properties));
-                        foreach (var descriptor in characteristic.GetDescriptors())
+                        foreach (var serialPort in
+                            (((HidDevice)dev).GetSerialPorts()))
                         {
-                            Console.WriteLine(string.Format("\t\t\tDescriptor: {0}", descriptor.Uuid));
+                            Console.WriteLine("    " + serialPort);
                         }
                     }
+                    */
+                }
 
-                    if (service.Uuid == new BleUuid("63dc0001-fa35-4205-b09f-0fc6072ec515"))
+                var bleDeviceList = list.GetBleDevices().ToArray();
+                Console.WriteLine("BLE device list:");
+                foreach (BleDevice dev in bleDeviceList)
+                {
+                    Console.WriteLine(dev.ToString() + "@" + dev.DevicePath);
+                    foreach (var service in dev.GetServices())
                     {
-                        try
+                        Console.WriteLine(string.Format("\tService: {0}", service.Uuid));
+                        foreach (var characteristic in service.GetCharacteristics())
                         {
-                            using (var svc = dev.Open(service))
+                            Console.WriteLine(string.Format("\t\tCharacteristic: {0} (Properties: {1})", characteristic.Uuid, characteristic.Properties));
+                            foreach (var descriptor in characteristic.GetDescriptors())
                             {
-                                Console.WriteLine("Opened!");
-
-                                BleCharacteristic rx = null;
-
-                                foreach (var ch in service.GetCharacteristics())
-                                {
-                                    Console.WriteLine(string.Format("{0} = {1}", ch.Uuid, ch.IsReadable ? string.Join(" ", svc.ReadCharacteristic(ch)) : "N/A"));
-
-                                    foreach (var d in ch.GetDescriptors())
-                                    {
-                                        Console.WriteLine(string.Format("\t{0} = {1}", d.Uuid, string.Join(" ", svc.ReadDescriptor(d))));
-                                    }
-
-                                    if (BleCccd.Notification != svc.ReadCccd(ch))
-                                    {
-                                        svc.WriteCccd(ch, BleCccd.Notification);
-                                    }
-
-                                    if (ch.Uuid == new BleUuid("63dc0002-fa35-4205-b09f-0fc6072ec515")) { rx = ch; }
-                                }
-
-                                Action beginReadEvent = null;
-                                AsyncCallback endReadEvent = null;
-                                beginReadEvent = () =>
-                                    {
-                                        svc.BeginReadEvent(endReadEvent, null);
-                                    };
-                                endReadEvent = ar =>
-                                    {
-                                        BleEvent @event;
-
-                                        try
-                                        {
-                                            @event = svc.EndReadEvent(ar);
-                                        }
-                                        catch (ObjectDisposedException)
-                                        {
-                                            Console.WriteLine("closed");
-                                            return;
-                                        }
-                                        catch (TimeoutException)
-                                        {
-                                            Console.WriteLine("timed out");
-                                            @event = default(BleEvent);
-                                        }
-
-                                        if (@event.Value != null)
-                                        {
-                                            Console.WriteLine(string.Format("{0} -> {1}", @event.Characteristic, string.Join(" ", @event.Value.Select(x => x.ToString()))));
-
-                                            if (rx != null)
-                                            {
-                                                Console.WriteLine("writing");
-                                                svc.WriteCharacteristicWithoutResponse(rx, new[] { (byte)0xdd, (byte)1, (byte)'A' });
-                                            }
-                                        }
-                                        beginReadEvent();
-                                    };
-                                beginReadEvent();
-
-                                Thread.Sleep(30000);
+                                Console.WriteLine(string.Format("\t\t\tDescriptor: {0}", descriptor.Uuid));
                             }
                         }
-                        catch (Exception e)
+
+                        if (service.Uuid == new BleUuid("63dc0001-fa35-4205-b09f-0fc6072ec515"))
                         {
-                            Console.WriteLine(e.ToString());
+                            try
+                            {
+                                using (var svc = dev.Open(service))
+                                {
+                                    Console.WriteLine("Opened!");
+
+                                    BleCharacteristic rx = null;
+
+                                    foreach (var ch in service.GetCharacteristics())
+                                    {
+                                        Console.WriteLine(string.Format("{0} = {1}", ch.Uuid, ch.IsReadable ? string.Join(" ", svc.ReadCharacteristic(ch)) : "N/A"));
+
+                                        foreach (var d in ch.GetDescriptors())
+                                        {
+                                            Console.WriteLine(string.Format("\t{0} = {1}", d.Uuid, string.Join(" ", svc.ReadDescriptor(d))));
+                                        }
+
+                                        if (BleCccd.Notification != svc.ReadCccd(ch))
+                                        {
+                                            svc.WriteCccd(ch, BleCccd.Notification);
+                                        }
+
+                                        if (ch.Uuid == new BleUuid("63dc0002-fa35-4205-b09f-0fc6072ec515")) { rx = ch; }
+                                    }
+
+                                    Action beginReadEvent = null;
+                                    AsyncCallback endReadEvent = null;
+                                    beginReadEvent = () =>
+                                        {
+                                            svc.BeginReadEvent(endReadEvent, null);
+                                        };
+                                    endReadEvent = ar =>
+                                        {
+                                            BleEvent @event;
+
+                                            try
+                                            {
+                                                @event = svc.EndReadEvent(ar);
+                                            }
+                                            catch (ObjectDisposedException)
+                                            {
+                                                Console.WriteLine("closed");
+                                                return;
+                                            }
+                                            catch (TimeoutException)
+                                            {
+                                                Console.WriteLine("timed out");
+                                                @event = default(BleEvent);
+                                            }
+
+                                            if (@event.Value != null)
+                                            {
+                                                Console.WriteLine(string.Format("{0} -> {1}", @event.Characteristic, string.Join(" ", @event.Value.Select(x => x.ToString()))));
+
+                                                if (rx != null)
+                                                {
+                                                    Console.WriteLine("writing");
+                                                    svc.WriteCharacteristicWithoutResponse(rx, new[] { (byte)0xdd, (byte)1, (byte)'A' });
+                                                }
+                                            }
+                                            beginReadEvent();
+                                        };
+                                    beginReadEvent();
+
+                                    Thread.Sleep(30000);
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                Console.WriteLine(e.ToString());
+                            }
                         }
                     }
                 }
-            }
 
-            Console.WriteLine();
-            Console.WriteLine("Press any key");
-            Console.ReadKey();
-            Console.WriteLine();
+                Console.WriteLine();
+                Console.WriteLine("Press any key");
+                Console.ReadKey();
+                Console.WriteLine();
             }
             //Console.WriteLine("Ending discovery.");
 

--- a/HidSharp/AsyncResult.cs
+++ b/HidSharp/AsyncResult.cs
@@ -34,7 +34,8 @@ namespace HidSharp
         {
             lock (this)
             {
-                if (_isCompleted) { return; } _isCompleted = true;
+                if (_isCompleted) { return; }
+                _isCompleted = true;
                 if (_waitHandle != null) { _waitHandle.Set(); }
             }
 
@@ -47,7 +48,7 @@ namespace HidSharp
             AsyncCallback callback, object state)
         {
             var ar = new AsyncResult<T>(callback, state);
-            ThreadPool.QueueUserWorkItem(delegate(object self)
+            ThreadPool.QueueUserWorkItem(delegate (object self)
             {
                 try { ar.Result = operation(); }
                 catch (Exception e) { ar.Exception = e; }

--- a/HidSharp/DeviceStream.cs
+++ b/HidSharp/DeviceStream.cs
@@ -60,7 +60,7 @@ namespace HidSharp
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {
             Throw.If.OutOfRange(buffer, offset, count);
-            return AsyncResult<int>.BeginOperation(delegate()
+            return AsyncResult<int>.BeginOperation(delegate ()
             {
                 return Read(buffer, offset, count);
             }, callback, state);
@@ -76,7 +76,7 @@ namespace HidSharp
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {
             Throw.If.OutOfRange(buffer, offset, count);
-            return AsyncResult<int>.BeginOperation(delegate()
+            return AsyncResult<int>.BeginOperation(delegate ()
             {
                 Write(buffer, offset, count); return 0;
             }, callback, state);

--- a/HidSharp/Experimental/BleStream.cs
+++ b/HidSharp/Experimental/BleStream.cs
@@ -97,7 +97,7 @@ namespace HidSharp.Experimental
         public virtual IAsyncResult BeginWriteCharacteristicWithoutResponse(BleCharacteristic characteristic, byte[] value, int offset, int count, BleRequestFlags requestFlags,
                                                                             AsyncCallback callback, object state)
         {
-            return AsyncResult<int>.BeginOperation(delegate()
+            return AsyncResult<int>.BeginOperation(delegate ()
             {
                 WriteCharacteristicWithoutResponse(characteristic, value, offset, count, requestFlags); return 0;
             }, callback, state);
@@ -138,7 +138,7 @@ namespace HidSharp.Experimental
 
         public virtual IAsyncResult BeginReadEvent(AsyncCallback callback, object state)
         {
-            return AsyncResult<BleEvent>.BeginOperation(delegate()
+            return AsyncResult<BleEvent>.BeginOperation(delegate ()
             {
                 return ReadEvent();
             }, callback, state);

--- a/HidSharp/HidDevice.cs
+++ b/HidSharp/HidDevice.cs
@@ -143,7 +143,7 @@ namespace HidSharp
             DeviceStream baseStream;
             bool result = base.TryOpen(openConfig, out baseStream);
             stream = (HidStream)baseStream; return result;
-		}
+        }
 
         public override bool HasImplementationDetail(Guid detail)
         {

--- a/HidSharp/HidSharp.csproj
+++ b/HidSharp/HidSharp.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>HidSharpCore</AssemblyName>
     <RootNamespace>HidSharp</RootNamespace>
     <LangVersion>preview</LangVersion>
-    <NoWarn>CS8981</NoWarn>
+    <NoWarn>CS8981; CA1416</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/HidSharp/HidSharp.csproj
+++ b/HidSharp/HidSharp.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>HidSharpCore</AssemblyName>
     <RootNamespace>HidSharp</RootNamespace>
     <LangVersion>preview</LangVersion>
+    <NoWarn>CS8981</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/HidSharp/HidSharp.csproj
+++ b/HidSharp/HidSharp.csproj
@@ -6,7 +6,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>HidSharpCore</AssemblyName>
     <RootNamespace>HidSharp</RootNamespace>
-    <LangVersion>preview</LangVersion>
     <NoWarn>CS8981; CA1416</NoWarn>
   </PropertyGroup>
 

--- a/HidSharp/HidSharp.csproj
+++ b/HidSharp/HidSharp.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>HidSharpCore</AssemblyName>
     <RootNamespace>HidSharp</RootNamespace>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <PackageId>HidSharpCore</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/HidSharp/HidStream.cs
+++ b/HidSharp/HidStream.cs
@@ -39,7 +39,7 @@ namespace HidSharp
         /// <exclude />
         public override void Flush()
         {
-            
+
         }
 
         /// <summary>
@@ -98,8 +98,8 @@ namespace HidSharp
         /// <param name="buffer">The buffer of data to send. Place the Report ID in the byte at index <paramref name="offset"/>.</param>
         /// <param name="offset">The index in the buffer to start the write from.</param>
         /// <param name="count">The number of bytes in the feature request.</param>
-        public abstract void SetFeature(byte[] buffer, int offset, int count);	
-		
+        public abstract void SetFeature(byte[] buffer, int offset, int count);
+
         /// <summary>
         /// Writes an HID Output Report to the device.
         /// </summary>

--- a/HidSharp/OpenConfiguration.cs
+++ b/HidSharp/OpenConfiguration.cs
@@ -58,7 +58,7 @@ namespace HidSharp
         public object GetOption(OpenOption option)
         {
             Throw.If.Null(option, "option");
-            
+
             object value;
             return _options.TryGetValue(option, out value) ? value : option.DefaultValue;
         }

--- a/HidSharp/OpenPriority.cs
+++ b/HidSharp/OpenPriority.cs
@@ -26,7 +26,7 @@ namespace HidSharp
         /// The lowest priority.
         /// </summary>
         Idle = -2,
-        
+
         /// <summary>
         /// Very low priority.
         /// </summary>

--- a/HidSharp/Platform/HidSelector.cs
+++ b/HidSharp/Platform/HidSelector.cs
@@ -22,7 +22,7 @@ namespace HidSharp.Platform
     sealed class HidSelector
     {
         public static readonly HidManager Instance;
-        static readonly Thread ManagerThread; 
+        static readonly Thread ManagerThread;
 
         static HidSelector()
         {

--- a/HidSharp/Platform/Libusb/LibusbHidManager.cs
+++ b/HidSharp/Platform/Libusb/LibusbHidManager.cs
@@ -19,9 +19,9 @@ using System;
 
 namespace HidSharp.Platform.Libusb
 {
-	sealed class LibusbHidManager
-	{
-		// TODO
-	}
+    sealed class LibusbHidManager
+    {
+        // TODO
+    }
 }
 

--- a/HidSharp/Platform/Libusb/NativeMethods.cs
+++ b/HidSharp/Platform/Libusb/NativeMethods.cs
@@ -23,7 +23,7 @@ namespace HidSharp.Platform.Libusb
 	static class NativeMethods
 	{
 		const string Libusb = "libusb-1.0";
-		
+
         [StructLayout(LayoutKind.Sequential)]
 		public struct DeviceDescriptor
 		{
@@ -33,14 +33,14 @@ namespace HidSharp.Platform.Libusb
 			public ushort idVendor, idProduct, bcdDevice;
 			public byte iManufacturer, iProduct, iSerialNumber, bNumConfigurations;
 		}
-	
+
 		public enum DeviceClass : byte
 		{
 			HID = 0x03,
 			MassStorage = 0x08,
 			VendorSpecific = 0xff
 		}
-		
+
 		public enum DescriptorType : byte
 		{
 			Device = 0x01,
@@ -53,18 +53,18 @@ namespace HidSharp.Platform.Libusb
 			Physical = 0x23,
 			Hub = 0x29
 		}
-		
+
 		public enum EndpointDirection : byte
 		{
 			In = 0x80,
 			Out = 0,
 		}
-		
+
 		public enum Request : byte
 		{
 			GetDescriptor = 0x06
 		}
-		
+
 		public enum RequestRecipient : byte
 		{
 			Device = 0,
@@ -72,27 +72,31 @@ namespace HidSharp.Platform.Libusb
 			Endpoint = 2,
 			Other = 3
 		}
-		
+
 		public enum RequestType : byte
 		{
 			Standard = 0x00,
 			Class = 0x20,
 			Vendor = 0x40
 		}
-		
+
 		public enum TransferType : byte
 		{
 			Control = 0,
 			Isochronous,
 			Bulk,
-			Interrupt	
+			Interrupt
 		}
-		
+
+#pragma warning disable CS0649
+
 		public struct Version
 		{
 			public ushort Major, Minor, Micro, Nano;
 		}
-		
+
+#pragma warning restore CS0649
+
 		public enum Error
 		{
 			None = 0,
@@ -109,82 +113,82 @@ namespace HidSharp.Platform.Libusb
 			OutOfMemory = -11,
 			NotSupported = -12
 		}
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_init(out IntPtr context);
-		
+
 		[DllImport(Libusb)]
 		public static extern void libusb_set_debug(IntPtr context, int level);
-		
+
 		[DllImport(Libusb)]
 		public static extern void libusb_exit(IntPtr context);
-		
+
 		[DllImport(Libusb)]
 		public static unsafe extern uint libusb_get_device_list(IntPtr context, out IntPtr list);
-		
+
 		[DllImport(Libusb)]
 		public static unsafe extern void libusb_free_device_list(IntPtr context, IntPtr list);
-		
+
 		[DllImport(Libusb)]
 		public static extern IntPtr libusb_ref_device(IntPtr device);
-		
+
 		[DllImport(Libusb)]
 		public static extern void libusb_unref_device(IntPtr device);
-		
+
 		[DllImport(Libusb)]
 		public static extern int libusb_get_max_packet_size(IntPtr device, byte endpoint);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_open(IntPtr device, out IntPtr deviceHandle);
 
 		[DllImport(Libusb)]
 		public static extern IntPtr libusb_open_device_with_vid_pid(IntPtr context, ushort idVendor, ushort idProduct);
-		
+
 		[DllImport(Libusb)]
 		public static extern void libusb_close(IntPtr deviceHandle);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_get_configuration(IntPtr deviceHandle, out int configuration);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_set_configuration(IntPtr deviceHandle, int configuration);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_claim_interface(IntPtr deviceHandle, int @interface);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_release_interface(IntPtr deviceHandle, int @interface);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_set_interface_alt_setting(IntPtr deviceHandle, int @interface, int altSetting);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_clear_halt(IntPtr deviceHandle, byte endpoint);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_reset_device(IntPtr deviceHandle);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_kernel_driver_active(IntPtr deviceHandle, int @interface);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_detach_kernel_driver(IntPtr deviceHandle, int @interface);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_attach_kernel_driver(IntPtr deviceHandle, int @interface);
-		
+
 		[DllImport(Libusb)]
 		public static extern IntPtr libusb_get_version();
-				
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_get_device_descriptor(IntPtr device, out DeviceDescriptor descriptor);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_get_active_config_descriptor(IntPtr device, out IntPtr configuration);
 
 		[DllImport(Libusb)]
 		public static extern Error libusb_get_config_descriptor_by_value(IntPtr device, byte index, out IntPtr configuration);
-		
+
 		[DllImport(Libusb)]
 		public static extern void libusb_free_config_descriptor(IntPtr configuration);
 
@@ -201,28 +205,28 @@ namespace HidSharp.Platform.Libusb
 			return libusb_get_descriptor_core(deviceHandle,
 			                                  type, index, data, wLength, 0);
 		}
-		
+
 		public static Error libusb_get_string_descriptor(IntPtr deviceHandle, DescriptorType type, byte index, ushort languageID, byte[] data, ushort wLength)
 		{
 			return libusb_get_descriptor_core(deviceHandle,
 			                                  DescriptorType.String, index,
-			                                  data, wLength, languageID);	
+			                                  data, wLength, languageID);
 		}
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_control_transfer(IntPtr deviceHandle,
 		                                            	   byte bmRequestType, byte bRequest,
 		                                            	   ushort wValue, ushort wIndex,
 		                                            	   byte[] data, ushort wLength,
 		                                            	   uint timeout);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_bulk_transfer(IntPtr deviceHandle,
 		                                         	    byte endpoint,
 		                                         	    byte[] data, int length,
 		                                         	    out int transferred,
 		                                         	    uint timeout);
-		
+
 		[DllImport(Libusb)]
 		public static extern Error libusb_interrupt_transfer(IntPtr deviceHandle,
 		                                         	  	     byte endpoint,
@@ -231,4 +235,3 @@ namespace HidSharp.Platform.Libusb
 		                                         	  	     uint timeout);
 	}
 }
-

--- a/HidSharp/Platform/Libusb/NativeMethods.cs
+++ b/HidSharp/Platform/Libusb/NativeMethods.cs
@@ -20,218 +20,218 @@ using System.Runtime.InteropServices;
 
 namespace HidSharp.Platform.Libusb
 {
-	static class NativeMethods
-	{
-		const string Libusb = "libusb-1.0";
+    static class NativeMethods
+    {
+        const string Libusb = "libusb-1.0";
 
         [StructLayout(LayoutKind.Sequential)]
-		public struct DeviceDescriptor
-		{
-			public byte bLength, bDescriptorType;
-			public ushort bcdUSB;
-			public byte bDeviceClass, bDeviceSubClass, bDeviceProtocol, bMaxPacketSize0;
-			public ushort idVendor, idProduct, bcdDevice;
-			public byte iManufacturer, iProduct, iSerialNumber, bNumConfigurations;
-		}
+        public struct DeviceDescriptor
+        {
+            public byte bLength, bDescriptorType;
+            public ushort bcdUSB;
+            public byte bDeviceClass, bDeviceSubClass, bDeviceProtocol, bMaxPacketSize0;
+            public ushort idVendor, idProduct, bcdDevice;
+            public byte iManufacturer, iProduct, iSerialNumber, bNumConfigurations;
+        }
 
-		public enum DeviceClass : byte
-		{
-			HID = 0x03,
-			MassStorage = 0x08,
-			VendorSpecific = 0xff
-		}
+        public enum DeviceClass : byte
+        {
+            HID = 0x03,
+            MassStorage = 0x08,
+            VendorSpecific = 0xff
+        }
 
-		public enum DescriptorType : byte
-		{
-			Device = 0x01,
-			Configuration = 0x02,
-			String = 0x03,
-			Interface = 0x04,
-			Endpoint = 0x05,
-			HID = 0x21,
-			Report = 0x22,
-			Physical = 0x23,
-			Hub = 0x29
-		}
+        public enum DescriptorType : byte
+        {
+            Device = 0x01,
+            Configuration = 0x02,
+            String = 0x03,
+            Interface = 0x04,
+            Endpoint = 0x05,
+            HID = 0x21,
+            Report = 0x22,
+            Physical = 0x23,
+            Hub = 0x29
+        }
 
-		public enum EndpointDirection : byte
-		{
-			In = 0x80,
-			Out = 0,
-		}
+        public enum EndpointDirection : byte
+        {
+            In = 0x80,
+            Out = 0,
+        }
 
-		public enum Request : byte
-		{
-			GetDescriptor = 0x06
-		}
+        public enum Request : byte
+        {
+            GetDescriptor = 0x06
+        }
 
-		public enum RequestRecipient : byte
-		{
-			Device = 0,
-			Interface = 1,
-			Endpoint = 2,
-			Other = 3
-		}
+        public enum RequestRecipient : byte
+        {
+            Device = 0,
+            Interface = 1,
+            Endpoint = 2,
+            Other = 3
+        }
 
-		public enum RequestType : byte
-		{
-			Standard = 0x00,
-			Class = 0x20,
-			Vendor = 0x40
-		}
+        public enum RequestType : byte
+        {
+            Standard = 0x00,
+            Class = 0x20,
+            Vendor = 0x40
+        }
 
-		public enum TransferType : byte
-		{
-			Control = 0,
-			Isochronous,
-			Bulk,
-			Interrupt
-		}
+        public enum TransferType : byte
+        {
+            Control = 0,
+            Isochronous,
+            Bulk,
+            Interrupt
+        }
 
 #pragma warning disable CS0649
 
-		public struct Version
-		{
-			public ushort Major, Minor, Micro, Nano;
-		}
+        public struct Version
+        {
+            public ushort Major, Minor, Micro, Nano;
+        }
 
 #pragma warning restore CS0649
 
-		public enum Error
-		{
-			None = 0,
-			IO = -1,
-			InvalidParameter = -2,
-			AccessDenied = -3,
-			NoDevice = -4,
-			NotFound = -5,
-			Busy = -6,
-			Timeout = -7,
-			Overflow = -8,
-			Pipe = -9,
-			Interrupted = -10,
-			OutOfMemory = -11,
-			NotSupported = -12
-		}
+        public enum Error
+        {
+            None = 0,
+            IO = -1,
+            InvalidParameter = -2,
+            AccessDenied = -3,
+            NoDevice = -4,
+            NotFound = -5,
+            Busy = -6,
+            Timeout = -7,
+            Overflow = -8,
+            Pipe = -9,
+            Interrupted = -10,
+            OutOfMemory = -11,
+            NotSupported = -12
+        }
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_init(out IntPtr context);
+        [DllImport(Libusb)]
+        public static extern Error libusb_init(out IntPtr context);
 
-		[DllImport(Libusb)]
-		public static extern void libusb_set_debug(IntPtr context, int level);
+        [DllImport(Libusb)]
+        public static extern void libusb_set_debug(IntPtr context, int level);
 
-		[DllImport(Libusb)]
-		public static extern void libusb_exit(IntPtr context);
+        [DllImport(Libusb)]
+        public static extern void libusb_exit(IntPtr context);
 
-		[DllImport(Libusb)]
-		public static unsafe extern uint libusb_get_device_list(IntPtr context, out IntPtr list);
+        [DllImport(Libusb)]
+        public static unsafe extern uint libusb_get_device_list(IntPtr context, out IntPtr list);
 
-		[DllImport(Libusb)]
-		public static unsafe extern void libusb_free_device_list(IntPtr context, IntPtr list);
+        [DllImport(Libusb)]
+        public static unsafe extern void libusb_free_device_list(IntPtr context, IntPtr list);
 
-		[DllImport(Libusb)]
-		public static extern IntPtr libusb_ref_device(IntPtr device);
+        [DllImport(Libusb)]
+        public static extern IntPtr libusb_ref_device(IntPtr device);
 
-		[DllImport(Libusb)]
-		public static extern void libusb_unref_device(IntPtr device);
+        [DllImport(Libusb)]
+        public static extern void libusb_unref_device(IntPtr device);
 
-		[DllImport(Libusb)]
-		public static extern int libusb_get_max_packet_size(IntPtr device, byte endpoint);
+        [DllImport(Libusb)]
+        public static extern int libusb_get_max_packet_size(IntPtr device, byte endpoint);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_open(IntPtr device, out IntPtr deviceHandle);
+        [DllImport(Libusb)]
+        public static extern Error libusb_open(IntPtr device, out IntPtr deviceHandle);
 
-		[DllImport(Libusb)]
-		public static extern IntPtr libusb_open_device_with_vid_pid(IntPtr context, ushort idVendor, ushort idProduct);
+        [DllImport(Libusb)]
+        public static extern IntPtr libusb_open_device_with_vid_pid(IntPtr context, ushort idVendor, ushort idProduct);
 
-		[DllImport(Libusb)]
-		public static extern void libusb_close(IntPtr deviceHandle);
+        [DllImport(Libusb)]
+        public static extern void libusb_close(IntPtr deviceHandle);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_get_configuration(IntPtr deviceHandle, out int configuration);
+        [DllImport(Libusb)]
+        public static extern Error libusb_get_configuration(IntPtr deviceHandle, out int configuration);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_set_configuration(IntPtr deviceHandle, int configuration);
+        [DllImport(Libusb)]
+        public static extern Error libusb_set_configuration(IntPtr deviceHandle, int configuration);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_claim_interface(IntPtr deviceHandle, int @interface);
+        [DllImport(Libusb)]
+        public static extern Error libusb_claim_interface(IntPtr deviceHandle, int @interface);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_release_interface(IntPtr deviceHandle, int @interface);
+        [DllImport(Libusb)]
+        public static extern Error libusb_release_interface(IntPtr deviceHandle, int @interface);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_set_interface_alt_setting(IntPtr deviceHandle, int @interface, int altSetting);
+        [DllImport(Libusb)]
+        public static extern Error libusb_set_interface_alt_setting(IntPtr deviceHandle, int @interface, int altSetting);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_clear_halt(IntPtr deviceHandle, byte endpoint);
+        [DllImport(Libusb)]
+        public static extern Error libusb_clear_halt(IntPtr deviceHandle, byte endpoint);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_reset_device(IntPtr deviceHandle);
+        [DllImport(Libusb)]
+        public static extern Error libusb_reset_device(IntPtr deviceHandle);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_kernel_driver_active(IntPtr deviceHandle, int @interface);
+        [DllImport(Libusb)]
+        public static extern Error libusb_kernel_driver_active(IntPtr deviceHandle, int @interface);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_detach_kernel_driver(IntPtr deviceHandle, int @interface);
+        [DllImport(Libusb)]
+        public static extern Error libusb_detach_kernel_driver(IntPtr deviceHandle, int @interface);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_attach_kernel_driver(IntPtr deviceHandle, int @interface);
+        [DllImport(Libusb)]
+        public static extern Error libusb_attach_kernel_driver(IntPtr deviceHandle, int @interface);
 
-		[DllImport(Libusb)]
-		public static extern IntPtr libusb_get_version();
+        [DllImport(Libusb)]
+        public static extern IntPtr libusb_get_version();
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_get_device_descriptor(IntPtr device, out DeviceDescriptor descriptor);
+        [DllImport(Libusb)]
+        public static extern Error libusb_get_device_descriptor(IntPtr device, out DeviceDescriptor descriptor);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_get_active_config_descriptor(IntPtr device, out IntPtr configuration);
+        [DllImport(Libusb)]
+        public static extern Error libusb_get_active_config_descriptor(IntPtr device, out IntPtr configuration);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_get_config_descriptor_by_value(IntPtr device, byte index, out IntPtr configuration);
+        [DllImport(Libusb)]
+        public static extern Error libusb_get_config_descriptor_by_value(IntPtr device, byte index, out IntPtr configuration);
 
-		[DllImport(Libusb)]
-		public static extern void libusb_free_config_descriptor(IntPtr configuration);
+        [DllImport(Libusb)]
+        public static extern void libusb_free_config_descriptor(IntPtr configuration);
 
-		static Error libusb_get_descriptor_core(IntPtr deviceHandle, DescriptorType type, byte index, byte[] data, ushort wLength, ushort wIndex)
-		{
-			return libusb_control_transfer(deviceHandle,
-			                               (byte)EndpointDirection.In, (byte)Request.GetDescriptor,
-			                               (ushort)((byte)DescriptorType.String << 8 | index),
-			                               wIndex, data, wLength, 1000);
-		}
+        static Error libusb_get_descriptor_core(IntPtr deviceHandle, DescriptorType type, byte index, byte[] data, ushort wLength, ushort wIndex)
+        {
+            return libusb_control_transfer(deviceHandle,
+                                           (byte)EndpointDirection.In, (byte)Request.GetDescriptor,
+                                           (ushort)((byte)DescriptorType.String << 8 | index),
+                                           wIndex, data, wLength, 1000);
+        }
 
-		public static Error libusb_get_descriptor(IntPtr deviceHandle, DescriptorType type, byte index, byte[] data, ushort wLength)
-		{
-			return libusb_get_descriptor_core(deviceHandle,
-			                                  type, index, data, wLength, 0);
-		}
+        public static Error libusb_get_descriptor(IntPtr deviceHandle, DescriptorType type, byte index, byte[] data, ushort wLength)
+        {
+            return libusb_get_descriptor_core(deviceHandle,
+                                              type, index, data, wLength, 0);
+        }
 
-		public static Error libusb_get_string_descriptor(IntPtr deviceHandle, DescriptorType type, byte index, ushort languageID, byte[] data, ushort wLength)
-		{
-			return libusb_get_descriptor_core(deviceHandle,
-			                                  DescriptorType.String, index,
-			                                  data, wLength, languageID);
-		}
+        public static Error libusb_get_string_descriptor(IntPtr deviceHandle, DescriptorType type, byte index, ushort languageID, byte[] data, ushort wLength)
+        {
+            return libusb_get_descriptor_core(deviceHandle,
+                                              DescriptorType.String, index,
+                                              data, wLength, languageID);
+        }
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_control_transfer(IntPtr deviceHandle,
-		                                            	   byte bmRequestType, byte bRequest,
-		                                            	   ushort wValue, ushort wIndex,
-		                                            	   byte[] data, ushort wLength,
-		                                            	   uint timeout);
+        [DllImport(Libusb)]
+        public static extern Error libusb_control_transfer(IntPtr deviceHandle,
+                                                           byte bmRequestType, byte bRequest,
+                                                           ushort wValue, ushort wIndex,
+                                                           byte[] data, ushort wLength,
+                                                           uint timeout);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_bulk_transfer(IntPtr deviceHandle,
-		                                         	    byte endpoint,
-		                                         	    byte[] data, int length,
-		                                         	    out int transferred,
-		                                         	    uint timeout);
+        [DllImport(Libusb)]
+        public static extern Error libusb_bulk_transfer(IntPtr deviceHandle,
+                                                         byte endpoint,
+                                                         byte[] data, int length,
+                                                         out int transferred,
+                                                         uint timeout);
 
-		[DllImport(Libusb)]
-		public static extern Error libusb_interrupt_transfer(IntPtr deviceHandle,
-		                                         	  	     byte endpoint,
-		                                         	  	     byte[] data, int length,
-		                                         	  	     out int transferred,
-		                                         	  	     uint timeout);
-	}
+        [DllImport(Libusb)]
+        public static extern Error libusb_interrupt_transfer(IntPtr deviceHandle,
+                                                                byte endpoint,
+                                                                byte[] data, int length,
+                                                                out int transferred,
+                                                                uint timeout);
+    }
 }

--- a/HidSharp/Platform/Linux/LinuxHidManager.cs
+++ b/HidSharp/Platform/Linux/LinuxHidManager.cs
@@ -69,7 +69,7 @@ namespace HidSharp.Platform.Linux
                             if (0 == (fds[0].revents & NativeMethods.pollev.IN))
                             {
                                 IntPtr device = NativeMethodsLibudev.Instance.udev_monitor_receive_device(monitor);
-                                if (device != null)
+                                if (device != IntPtr.Zero)
                                 {
                                     NativeMethodsLibudev.Instance.udev_device_unref(device);
 

--- a/HidSharp/Platform/Linux/LinuxHidStream.cs
+++ b/HidSharp/Platform/Linux/LinuxHidStream.cs
@@ -26,122 +26,122 @@ namespace HidSharp.Platform.Linux
 {
     sealed class LinuxHidStream : SysHidStream
     {
-		Queue<byte[]> _inputQueue;
-		Queue<CommonOutputReport> _outputQueue;
-		
-		int _handle;
-		Thread _readThread, _writeThread;
-		volatile bool _shutdown;
-		
+        Queue<byte[]> _inputQueue;
+        Queue<CommonOutputReport> _outputQueue;
+
+        int _handle;
+        Thread _readThread, _writeThread;
+        volatile bool _shutdown;
+
         internal LinuxHidStream(LinuxHidDevice device)
             : base(device)
         {
-			_inputQueue = new Queue<byte[]>();
-			_outputQueue = new Queue<CommonOutputReport>();
-			_handle = -1;
+            _inputQueue = new Queue<byte[]>();
+            _outputQueue = new Queue<CommonOutputReport>();
+            _handle = -1;
             _readThread = new Thread(ReadThread) { IsBackground = true, Name = "HID Reader" };
             _writeThread = new Thread(WriteThread) { IsBackground = true, Name = "HID Writer" };
         }
-		
-		internal static int DeviceHandleFromPath(string path, HidDevice hidDevice, NativeMethods.oflag oflag)
-		{
+
+        internal static int DeviceHandleFromPath(string path, HidDevice hidDevice, NativeMethods.oflag oflag)
+        {
             IntPtr udev = NativeMethodsLibudev.Instance.udev_new();
-			if (IntPtr.Zero != udev)
-			{
-				try
-				{
-					IntPtr device = NativeMethodsLibudev.Instance.udev_device_new_from_syspath(udev, path);
-					if (IntPtr.Zero != device)
-					{
-						try
-						{
+            if (IntPtr.Zero != udev)
+            {
+                try
+                {
+                    IntPtr device = NativeMethodsLibudev.Instance.udev_device_new_from_syspath(udev, path);
+                    if (IntPtr.Zero != device)
+                    {
+                        try
+                        {
                             string devnode = NativeMethodsLibudev.Instance.udev_device_get_devnode(device);
-							if (devnode != null)
-							{
-								int handle = NativeMethods.retry(() => NativeMethods.open(devnode, oflag));
-								if (handle < 0)
-								{
-									var error = (NativeMethods.error)Marshal.GetLastWin32Error();
-									if (error == NativeMethods.error.EACCES)
-									{
+                            if (devnode != null)
+                            {
+                                int handle = NativeMethods.retry(() => NativeMethods.open(devnode, oflag));
+                                if (handle < 0)
+                                {
+                                    var error = (NativeMethods.error)Marshal.GetLastWin32Error();
+                                    if (error == NativeMethods.error.EACCES)
+                                    {
                                         throw DeviceException.CreateUnauthorizedAccessException(hidDevice, "Not permitted to open HID class device at " + devnode + ".");
-									}
-									else
-									{
+                                    }
+                                    else
+                                    {
                                         throw DeviceException.CreateIOException(hidDevice, "Unable to open HID class device (" + error.ToString() + ").");
-									}
-								}
-								return handle;
-							}
-						}
-						finally
-						{
+                                    }
+                                }
+                                return handle;
+                            }
+                        }
+                        finally
+                        {
                             NativeMethodsLibudev.Instance.udev_device_unref(device);
-						}
-					}
-				}
-				finally
-				{
+                        }
+                    }
+                }
+                finally
+                {
                     NativeMethodsLibudev.Instance.udev_unref(udev);
-				}
-			}
-			
-			throw new FileNotFoundException("HID class device not found.");
-		}
-		
+                }
+            }
+
+            throw new FileNotFoundException("HID class device not found.");
+        }
+
         internal void Init(string path)
         {
-			int handle;
+            int handle;
             handle = DeviceHandleFromPath(path, Device, NativeMethods.oflag.RDWR | NativeMethods.oflag.NONBLOCK);
-			
-			_handle = handle;
-			HandleInitAndOpen();
-			
-			_readThread.Start();
-			_writeThread.Start();
+
+            _handle = handle;
+            HandleInitAndOpen();
+
+            _readThread.Start();
+            _writeThread.Start();
         }
-		
+
         protected override void Dispose(bool disposing)
         {
-			if (!HandleClose()) { return; }
-			
+            if (!HandleClose()) { return; }
+
             _shutdown = true;
             try { lock (_inputQueue) { Monitor.PulseAll(_inputQueue); } } catch { }
-			try { lock (_outputQueue) { Monitor.PulseAll(_outputQueue); } } catch { }
+            try { lock (_outputQueue) { Monitor.PulseAll(_outputQueue); } } catch { }
 
             try { _readThread.Join(); } catch { }
             try { _writeThread.Join(); } catch { }
 
-			HandleRelease();
+            HandleRelease();
 
             base.Dispose(disposing);
-		}
-		
-		internal override void HandleFree()
-		{
-			NativeMethods.retry(() => NativeMethods.close(_handle)); _handle = -1;
-		}
-		
-		unsafe void ReadThread()
-		{
-			if (!HandleAcquire()) { return; }
-			
-			try
-			{
-				lock (_inputQueue)
-				{
+        }
+
+        internal override void HandleFree()
+        {
+            NativeMethods.retry(() => NativeMethods.close(_handle)); _handle = -1;
+        }
+
+        unsafe void ReadThread()
+        {
+            if (!HandleAcquire()) { return; }
+
+            try
+            {
+                lock (_inputQueue)
+                {
                     var pfd = new NativeMethods.pollfd();
-					pfd.fd = _handle;
-					pfd.events = NativeMethods.pollev.IN;
-						
-					while (!_shutdown)
-					{
-					tryReadAgain:
-						Monitor.Exit(_inputQueue);
+                    pfd.fd = _handle;
+                    pfd.events = NativeMethods.pollev.IN;
+
+                    while (!_shutdown)
+                    {
+                    tryReadAgain:
+                        Monitor.Exit(_inputQueue);
 
                         int ret;
-						try { ret = NativeMethods.poll(ref pfd, (IntPtr)1, 250); }
-						finally { Monitor.Enter(_inputQueue); }
+                        try { ret = NativeMethods.poll(ref pfd, (IntPtr)1, 250); }
+                        finally { Monitor.Enter(_inputQueue); }
                         if (ret != 1) { continue; }
 
                         if (0 != (pfd.revents & (NativeMethods.pollev.ERR | NativeMethods.pollev.HUP | NativeMethods.pollev.NVAL)))
@@ -149,41 +149,41 @@ namespace HidSharp.Platform.Linux
                             break;
                         }
 
-						if (0 != (pfd.revents & NativeMethods.pollev.IN))
-						{
+                        if (0 != (pfd.revents & NativeMethods.pollev.IN))
+                        {
                             // Linux doesn't provide a Report ID if the device doesn't use one.
                             int inputLength = Device.GetMaxInputReportLength();
                             if (inputLength > 0 && !((LinuxHidDevice)Device).ReportsUseID) { inputLength--; }
 
                             byte[] inputReport = new byte[inputLength];
-							fixed (byte* inputBytes = inputReport)
-							{
+                            fixed (byte* inputBytes = inputReport)
+                            {
                                 var inputBytesPtr = (IntPtr)inputBytes;
-								IntPtr length = NativeMethods.retry(() => NativeMethods.read
-									                            (_handle, inputBytesPtr, (UIntPtr)inputReport.Length));
-								if ((long)length < 0)
-								{
+                                IntPtr length = NativeMethods.retry(() => NativeMethods.read
+                                                                (_handle, inputBytesPtr, (UIntPtr)inputReport.Length));
+                                if ((long)length < 0)
+                                {
                                     var error = (NativeMethods.error)Marshal.GetLastWin32Error();
-									if (error != NativeMethods.error.EAGAIN) { break; }
-									goto tryReadAgain;
-								}
+                                    if (error != NativeMethods.error.EAGAIN) { break; }
+                                    goto tryReadAgain;
+                                }
 
-								Array.Resize(ref inputReport, (int)length); // No Report ID? First byte becomes Report ID 0.
+                                Array.Resize(ref inputReport, (int)length); // No Report ID? First byte becomes Report ID 0.
                                 if (!((LinuxHidDevice)Device).ReportsUseID) { inputReport = new byte[1].Concat(inputReport).ToArray(); }
-								_inputQueue.Enqueue(inputReport); Monitor.PulseAll(_inputQueue);
-							}
-						}
-					}
+                                _inputQueue.Enqueue(inputReport); Monitor.PulseAll(_inputQueue);
+                            }
+                        }
+                    }
 
                     CommonDisconnected(_inputQueue);
-				}
-			}
-			finally
-			{
-				HandleRelease();
-			}
-		}
-		
+                }
+            }
+            finally
+            {
+                HandleRelease();
+            }
+        }
+
         public override int Read(byte[] buffer, int offset, int count)
         {
             return CommonRead(buffer, offset, count, _inputQueue);
@@ -212,32 +212,32 @@ namespace HidSharp.Platform.Linux
             }
         }
 
-		unsafe void WriteThread()
-		{
-			if (!HandleAcquire()) { return; }
-			
-			try
-			{
-				lock (_outputQueue)
-				{
-					while (true)
-					{
-						while (!_shutdown && _outputQueue.Count == 0) { Monitor.Wait(_outputQueue); }
-						if (_shutdown) { break; }
+        unsafe void WriteThread()
+        {
+            if (!HandleAcquire()) { return; }
 
-						CommonOutputReport outputReport = _outputQueue.Peek();
+            try
+            {
+                lock (_outputQueue)
+                {
+                    while (true)
+                    {
+                        while (!_shutdown && _outputQueue.Count == 0) { Monitor.Wait(_outputQueue); }
+                        if (_shutdown) { break; }
+
+                        CommonOutputReport outputReport = _outputQueue.Peek();
 
                         byte[] outputBytesRaw = outputReport.Bytes;
                         // Linux doesn't expect a Report ID if the device doesn't use one.
                         //if (!((LinuxHidDevice)Device).ReportsUseID && outputBytesRaw.Length > 0) { outputBytesRaw = outputBytesRaw.Skip(1).ToArray(); }
                         // BUGFIX: Yes, it does. But only on write(). (HIDSharp 2.0.2)
 
-						try
-						{
-							fixed (byte* outputBytes = outputBytesRaw)
-							{
-								// hidraw is apparently blocking for output, even when O_NONBLOCK is used.
-								// See for yourself at drivers/hid/hidraw.c...
+                        try
+                        {
+                            fixed (byte* outputBytes = outputBytesRaw)
+                            {
+                                // hidraw is apparently blocking for output, even when O_NONBLOCK is used.
+                                // See for yourself at drivers/hid/hidraw.c...
                                 IntPtr length;
                                 Monitor.Exit(_outputQueue);
                                 try
@@ -251,23 +251,23 @@ namespace HidSharp.Platform.Linux
                                 {
                                     Monitor.Enter(_outputQueue);
                                 }
-							}
-						}
-						finally
-						{
-							_outputQueue.Dequeue();
+                            }
+                        }
+                        finally
+                        {
+                            _outputQueue.Dequeue();
                             outputReport.Done = true;
-							Monitor.PulseAll(_outputQueue);
-						}	
-					}
-				}
-			}
-			finally
-			{
-				HandleRelease();
-			}
-		}
-		
+                            Monitor.PulseAll(_outputQueue);
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                HandleRelease();
+            }
+        }
+
         public override void Write(byte[] buffer, int offset, int count)
         {
             CommonWrite(buffer, offset, count, _outputQueue, false, Device.GetMaxOutputReportLength());
@@ -283,7 +283,7 @@ namespace HidSharp.Platform.Linux
                 fixed (byte* ptr = buffer)
                 {
                     if (NativeMethods.ioctl(_handle, NativeMethods.HIDIOCSFEATURE(count), (IntPtr)(ptr + offset)) < 0)
-                        { throw new IOException("SetFeature failed."); }
+                    { throw new IOException("SetFeature failed."); }
                 }
             }
             finally

--- a/HidSharp/Platform/Linux/LinuxSerialStream.cs
+++ b/HidSharp/Platform/Linux/LinuxSerialStream.cs
@@ -183,7 +183,7 @@ namespace HidSharp.Platform.Linux
             {
                 int startTime = Environment.TickCount, writeTimeout = WriteTimeout;
 
-                for (int bytesWritten = 0; bytesWritten < count; )
+                for (int bytesWritten = 0; bytesWritten < count;)
                 {
                     int handle = _handle;
                     if (handle < 0) { throw new IOException("Closed."); }

--- a/HidSharp/Platform/Linux/NativeMethods.cs
+++ b/HidSharp/Platform/Linux/NativeMethods.cs
@@ -28,47 +28,47 @@ namespace HidSharp.Platform.Linux
 {
     static class NativeMethods
     {
-		const string libc = "libc";
+        const string libc = "libc";
 
-		public enum error
-		{
-			OK = 0,
-			EPERM = 1,
-			EINTR = 4,
-			EIO = 5,
-			ENXIO = 6,
-			EBADF = 9,
-			EAGAIN = 11,
-			EACCES = 13,
-			EBUSY = 16,
-			ENODEV = 19,
-			EINVAL = 22
-		}
-			
-		[Flags]
-		public enum oflag
-		{
-			RDONLY = 0x000,
-			WRONLY = 0x001,
-			RDWR = 0x002,
-			CREAT = 0x040,
-			EXCL = 0x080,
+        public enum error
+        {
+            OK = 0,
+            EPERM = 1,
+            EINTR = 4,
+            EIO = 5,
+            ENXIO = 6,
+            EBADF = 9,
+            EAGAIN = 11,
+            EACCES = 13,
+            EBUSY = 16,
+            ENODEV = 19,
+            EINVAL = 22
+        }
+
+        [Flags]
+        public enum oflag
+        {
+            RDONLY = 0x000,
+            WRONLY = 0x001,
+            RDWR = 0x002,
+            CREAT = 0x040,
+            EXCL = 0x080,
             NOCTTY = 0x100,
-			TRUNC = 0x200,
-			APPEND = 0x400,
-			NONBLOCK = 0x800
-		}
-	
-		[Flags]
-		public enum pollev : short
-		{
-			IN = 0x01,
-			PRI = 0x02,
-			OUT = 0x04,
-			ERR = 0x08,
-			HUP = 0x10,
-			NVAL = 0x20
-		}
+            TRUNC = 0x200,
+            APPEND = 0x400,
+            NONBLOCK = 0x800
+        }
+
+        [Flags]
+        public enum pollev : short
+        {
+            IN = 0x01,
+            PRI = 0x02,
+            OUT = 0x04,
+            ERR = 0x08,
+            HUP = 0x10,
+            NVAL = 0x20
+        }
 
         public enum ENDPOINT_DIRECTION
         {
@@ -88,38 +88,38 @@ namespace HidSharp.Platform.Linux
         }
 
         public struct pollfd
-		{
-			public int fd;
-			public pollev events;
-			public pollev revents;
-		}
+        {
+            public int fd;
+            public pollev events;
+            public pollev revents;
+        }
 
-		public static int retry(Func<int> sysfunc)
-		{
-			while (true)
-			{
+        public static int retry(Func<int> sysfunc)
+        {
+            while (true)
+            {
                 int ret = sysfunc(); var error = (error)Marshal.GetLastWin32Error();
                 if (ret >= 0 || error != error.EINTR) { return ret; }
-			}
-		}
+            }
+        }
 
-		public static IntPtr retry(Func<IntPtr> sysfunc)
-		{
-			while (true)
-			{
+        public static IntPtr retry(Func<IntPtr> sysfunc)
+        {
+            while (true)
+            {
                 IntPtr ret = sysfunc(); var error = (error)Marshal.GetLastWin32Error();
                 if ((long)ret >= 0 || error != error.EINTR) { return ret; }
-			}
-		}
+            }
+        }
 
-		public static bool uname(out string sysname, out Version release)
-		{
-			string releaseStr; release = null;
-			if (!uname(out sysname, out releaseStr)) { return false; }
+        public static bool uname(out string sysname, out Version release)
+        {
+            string releaseStr; release = null;
+            if (!uname(out sysname, out releaseStr)) { return false; }
             releaseStr = new string(releaseStr.Trim().TakeWhile(ch => (ch >= '0' && ch <= '9') || ch == '.').ToArray());
-			release = new Version(releaseStr);
-			return true;
-		}
+            release = new Version(releaseStr);
+            return true;
+        }
 
         public static bool uname(out string sysname, out string release)
         {
@@ -159,23 +159,23 @@ namespace HidSharp.Platform.Linux
             sysname = null; release = null;
             return false;
         }
-		
-		[DllImport(libc, SetLastError = true)]
-		public static extern int open(
-			[MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string filename,
-			 oflag oflag);
-		
-		[DllImport(libc, SetLastError = true)]
-		public static extern int close(int filedes);
 
-		[DllImport(libc, SetLastError = true)]
-		public static extern IntPtr read(int filedes, IntPtr buffer, UIntPtr size);
-		
-		[DllImport(libc, SetLastError = true)]
-		public static extern IntPtr write(int filedes, IntPtr buffer, UIntPtr size);
+        [DllImport(libc, SetLastError = true)]
+        public static extern int open(
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string filename,
+             oflag oflag);
 
-		[DllImport(libc, SetLastError = true)]
-		public static extern int poll(pollfd[] fds, IntPtr nfds, int timeout);
+        [DllImport(libc, SetLastError = true)]
+        public static extern int close(int filedes);
+
+        [DllImport(libc, SetLastError = true)]
+        public static extern IntPtr read(int filedes, IntPtr buffer, UIntPtr size);
+
+        [DllImport(libc, SetLastError = true)]
+        public static extern IntPtr write(int filedes, IntPtr buffer, UIntPtr size);
+
+        [DllImport(libc, SetLastError = true)]
+        public static extern int poll(pollfd[] fds, IntPtr nfds, int timeout);
 
         [DllImport(libc, SetLastError = true)]
         public static extern int poll(ref pollfd fds, IntPtr nfds, int timeout);

--- a/HidSharp/Platform/Linux/NativeMethodsLibudev.cs
+++ b/HidSharp/Platform/Linux/NativeMethodsLibudev.cs
@@ -53,39 +53,39 @@ namespace HidSharp.Platform.Linux
         }
 
         public abstract IntPtr udev_new();
-        
+
         public abstract IntPtr udev_ref(IntPtr udev);
-        
+
         public abstract void udev_unref(IntPtr udev);
-        
+
         public abstract IntPtr udev_monitor_new_from_netlink(IntPtr udev, string name);
-        
+
         public abstract void udev_monitor_unref(IntPtr monitor);
-        
+
         public abstract int udev_monitor_filter_add_match_subsystem_devtype(IntPtr monitor, string subsystem, string devtype);
-        
+
         public abstract int udev_monitor_enable_receiving(IntPtr monitor);
-        
+
         public abstract int udev_monitor_get_fd(IntPtr monitor);
-        
+
         public abstract IntPtr udev_monitor_receive_device(IntPtr monitor);
-        
+
         public abstract IntPtr udev_enumerate_new(IntPtr udev);
-        
+
         public abstract IntPtr udev_enumerate_ref(IntPtr enumerate);
-        
+
         public abstract void udev_enumerate_unref(IntPtr enumerate);
-        
+
         public abstract int udev_enumerate_add_match_subsystem(IntPtr enumerate, string subsystem);
-        
+
         public abstract int udev_enumerate_scan_devices(IntPtr enumerate);
-        
+
         public abstract IntPtr udev_enumerate_get_list_entry(IntPtr enumerate);
-        
+
         public abstract IntPtr udev_list_entry_get_next(IntPtr entry);
 
         public abstract string udev_list_entry_get_name(IntPtr entry);
-        
+
         public abstract IntPtr udev_device_new_from_syspath(IntPtr udev, string syspath);
 
         public abstract IntPtr udev_device_ref(IntPtr device);

--- a/HidSharp/Platform/MacOS/MacSerialStream.cs
+++ b/HidSharp/Platform/MacOS/MacSerialStream.cs
@@ -115,7 +115,7 @@ namespace HidSharp.Platform.MacOS
                 NativeMethods.retry(() => NativeMethods.tcdrain(handle));
             }
         }
-        
+
         // Make these timeouts not infinite, so that threads blocking on poll will exit.
         static int GetTimeout(int startTime, int rwTimeout)
         {
@@ -182,7 +182,7 @@ namespace HidSharp.Platform.MacOS
             {
                 int startTime = Environment.TickCount, writeTimeout = WriteTimeout;
 
-                for (int bytesWritten = 0; bytesWritten < count; )
+                for (int bytesWritten = 0; bytesWritten < count;)
                 {
                     int handle = _handle;
                     if (handle < 0) { throw new IOException("Closed."); }

--- a/HidSharp/Platform/MacOS/NativeMethods.cs
+++ b/HidSharp/Platform/MacOS/NativeMethods.cs
@@ -301,6 +301,8 @@ namespace HidSharp.Platform.MacOS
             public uint completionTimeout;
         }
 
+#pragma warning disable CS0649, CS0169
+
         [StructLayout(LayoutKind.Sequential)]
         public unsafe struct IOCFPlugInInterface
         {
@@ -466,6 +468,8 @@ namespace HidSharp.Platform.MacOS
             byte byte14;
             byte byte15;
         }
+
+#pragma warning restore CS0649, CS0169
 
         public static CFType ToCFType(this IntPtr handle)
         {

--- a/HidSharp/Platform/SystemEvents.cs
+++ b/HidSharp/Platform/SystemEvents.cs
@@ -1060,7 +1060,7 @@ namespace HidSharp.Platform.SystemEvents
 
         static string GetEventFilename(string kind, string name)
         {
-            string bs64 = Convert.ToBase64String(new SHA256Managed().ComputeHash(Encoding.UTF8.GetBytes(name))).Replace('+', '-').Replace('/', '_').Replace("=", "");
+            string bs64 = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(name))).Replace('+', '-').Replace('/', '_').Replace("=", "");
             string directory = GetEventDirectory(kind);
             string filename = Path.Combine(directory, bs64 + ".tmp");
             return filename;
@@ -1068,7 +1068,7 @@ namespace HidSharp.Platform.SystemEvents
 
         static string GetSHMFilename(string kind, string name)
         {
-            string shmName = string.Format("/HS.{0}.{1}", kind, Convert.ToBase64String(new SHA256Managed().ComputeHash(Encoding.UTF8.GetBytes(name))).Substring(0, 16).Replace('+', '-').Replace('/', '_'));
+            string shmName = string.Format("/HS.{0}.{1}", kind, Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(name))).Substring(0, 16).Replace('+', '-').Replace('/', '_'));
             return shmName;
         }
 
@@ -1422,7 +1422,7 @@ namespace HidSharp.Platform.SystemEvents
         static string GetGlobalName(string name)
         {
             if (name == null) { throw new ArgumentNullException(); }
-            if (name.Length > 240) { name = "HIDSharp Global (" + Convert.ToBase64String(new SHA256Managed().ComputeHash(Encoding.UTF8.GetBytes(name))) + ")"; }
+            if (name.Length > 240) { name = "HIDSharp Global (" + Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(name))) + ")"; }
             return @"Global\" + name;
         }
 

--- a/HidSharp/Platform/Utf8Marshaler.cs
+++ b/HidSharp/Platform/Utf8Marshaler.cs
@@ -42,7 +42,7 @@ namespace HidSharp.Platform
         public void CleanUpNativeData(IntPtr ptr)
         {
             var allocations = GetAllocations();
-			if (IntPtr.Zero == ptr || !allocations.Contains(ptr)) { return; }
+            if (IntPtr.Zero == ptr || !allocations.Contains(ptr)) { return; }
             Marshal.FreeHGlobal(ptr); allocations.Remove(ptr);
         }
 
@@ -77,12 +77,12 @@ namespace HidSharp.Platform
             string str = Encoding.UTF8.GetString(bytes);
             return str;
         }
-		
+
         // This method needs to keep its original name.
         [Obfuscation(Exclude = true)]
-		public static ICustomMarshaler GetInstance(string cookie)
-		{
-			return new Utf8Marshaler();
-		}
+        public static ICustomMarshaler GetInstance(string cookie)
+        {
+            return new Utf8Marshaler();
+        }
     }
 }

--- a/HidSharp/Platform/Windows/NativeMethods.cs
+++ b/HidSharp/Platform/Windows/NativeMethods.cs
@@ -339,7 +339,7 @@ namespace HidSharp.Platform.Windows
         public struct SP_DEVICE_INTERFACE_DETAIL_DATA
         {
             public int Size;
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst=1024)] public string DevicePath;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 1024)] public string DevicePath;
         }
 
         public enum HIDP_REPORT_TYPE
@@ -611,7 +611,7 @@ namespace HidSharp.Platform.Windows
 
             [FieldOffset(29)]
             public byte IsReadable;
-            
+
             [FieldOffset(30)]
             public byte IsWritable;
 
@@ -847,30 +847,30 @@ namespace HidSharp.Platform.Windows
         [Flags]
         public enum BDIF : uint
         {
-            Address          = 0x0000001,
-            Cod              = 0x0000002,
-            Name             = 0x0000004,
-            Paired           = 0x0000008,
-            Personal         = 0x0000010,
-            Connected        = 0x0000020,
-            ShortName        = 0x0000040,
-            Visible          = 0x0000080,
-            SspSupported     = 0x0000100,
-            SspPaired        = 0x0000200,
+            Address = 0x0000001,
+            Cod = 0x0000002,
+            Name = 0x0000004,
+            Paired = 0x0000008,
+            Personal = 0x0000010,
+            Connected = 0x0000020,
+            ShortName = 0x0000040,
+            Visible = 0x0000080,
+            SspSupported = 0x0000100,
+            SspPaired = 0x0000200,
             SspMitmProtected = 0x0000400,
-            Rssi             = 0x0001000,
-            Eir              = 0x0002000,
-            Br               = 0x0004000, // Windows 8
-            Le               = 0x0008000, // Windows 8
-            LePaired         = 0x0010000, // Windows 8
-            LePersonal       = 0x0020000, // Windows 8
-            LeMitmProtected  = 0x0040000, // Windows 8
+            Rssi = 0x0001000,
+            Eir = 0x0002000,
+            Br = 0x0004000, // Windows 8
+            Le = 0x0008000, // Windows 8
+            LePaired = 0x0010000, // Windows 8
+            LePersonal = 0x0020000, // Windows 8
+            LeMitmProtected = 0x0040000, // Windows 8
             LePrivacyEnabled = 0x0080000, // Windows 8
-            LeRandomAddress  = 0x0100000, // Windows 8
-            LeDiscoverable   = 0x0200000, // Windows 10
-            LeName           = 0x0400000, // Windows 10
-            Unknown1         = 0x1000000, // ???
-            Unknown2         = 0x2000000  // ???
+            LeRandomAddress = 0x0100000, // Windows 8
+            LeDiscoverable = 0x0200000, // Windows 10
+            LeName = 0x0400000, // Windows 10
+            Unknown1 = 0x1000000, // ???
+            Unknown2 = 0x2000000  // ???
         }
 
         // Reference:
@@ -953,7 +953,7 @@ namespace HidSharp.Platform.Windows
         public static int CM_Get_Device_ID(uint devInst, out string deviceID)
         {
             int ret; deviceID = null;
-            
+
             int length;
             ret = CM_Get_Device_ID_Size(out length, devInst);
             if (ret != 0) { return ret; }
@@ -1039,7 +1039,7 @@ namespace HidSharp.Platform.Windows
         [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool GetVersionEx(ref OSVERSIONINFO version);
-         
+
         [DllImport("hid.dll")]
         public static extern void HidD_GetHidGuid(out Guid hidGuid);
 
@@ -1366,12 +1366,12 @@ namespace HidSharp.Platform.Windows
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool CloseHandle(IntPtr handle);
 
-		public static bool CloseHandle(ref IntPtr handle)
-		{
-			if (!CloseHandle(handle)) { return false; }
-			handle = IntPtr.Zero; return true;
-		}
-		
+        public static bool CloseHandle(ref IntPtr handle)
+        {
+            if (!CloseHandle(handle)) { return false; }
+            handle = IntPtr.Zero; return true;
+        }
+
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public unsafe static extern bool ReadFile(IntPtr handle, byte* buffer, int bytesToRead,
@@ -1485,9 +1485,9 @@ namespace HidSharp.Platform.Windows
             int error;
 
             ushort allocated;
-            error = NativeMethods.BluetoothGATTGetCharacteristics(handle, ref service,  0, null, out allocated);
-            if (error == NativeMethods.ERROR_NOT_FOUND) { allocated = 0; } else
-            if (error != NativeMethods.ERROR_MORE_DATA) { return null; }
+            error = NativeMethods.BluetoothGATTGetCharacteristics(handle, ref service, 0, null, out allocated);
+            if (error == NativeMethods.ERROR_NOT_FOUND) { allocated = 0; }
+            else if (error != NativeMethods.ERROR_MORE_DATA) { return null; }
 
             var characteristics = new NativeMethods.BTH_LE_GATT_CHARACTERISTIC[allocated];
             if (allocated > 0)
@@ -1515,7 +1515,8 @@ namespace HidSharp.Platform.Windows
 
             ushort allocated;
             error = NativeMethods.BluetoothGATTGetDescriptors(handle, ref characteristic, 0, null, out allocated);
-            if (error == NativeMethods.ERROR_NOT_FOUND) { allocated = 0; } else
+            if (error == NativeMethods.ERROR_NOT_FOUND) { allocated = 0; }
+            else
             if (error != NativeMethods.ERROR_MORE_DATA) { return null; }
 
             var descriptors = new NativeMethods.BTH_LE_GATT_DESCRIPTOR[allocated];

--- a/HidSharp/Platform/Windows/WinBleStream.cs
+++ b/HidSharp/Platform/Windows/WinBleStream.cs
@@ -421,9 +421,9 @@ namespace HidSharp.Platform.Windows
 			HandleAcquireIfOpenOrFail();
             try
             {
+                IntPtr* handles = stackalloc IntPtr[2];
                 while (true)
                 {
-                    IntPtr* handles = stackalloc IntPtr[2];
                     handles[0] = _watchEventHandle; handles[1] = _closeEventHandle;
                     uint waitResult = NativeMethods.WaitForMultipleObjects(2, handles, false, NativeMethods.WaitForMultipleObjectsGetTimeout(ReadTimeout));
                     switch (waitResult)

--- a/HidSharp/Platform/Windows/WinBleStream.cs
+++ b/HidSharp/Platform/Windows/WinBleStream.cs
@@ -84,7 +84,7 @@ namespace HidSharp.Platform.Windows
                 for (int i = 0; i < watchedCharacteristics.Count; i++)
                 {
                     var wc = watchedCharacteristics[i];
-                    Marshal.StructureToPtr(wc.NativeData, (IntPtr)eb,false);
+                    Marshal.StructureToPtr(wc.NativeData, (IntPtr)eb, false);
                     eb += NativeMethods.BTH_LE_GATT_CHARACTERISTIC.Size;
 
                     _watchMap[wc.NativeData.AttributeHandle] = wc;
@@ -198,7 +198,7 @@ namespace HidSharp.Platform.Windows
         {
             Throw.If.Null(characteristic, "characteristic").Null(value, "value").OutOfRange(value, offset, count);
 
-			HandleAcquireIfOpenOrFail();
+            HandleAcquireIfOpenOrFail();
             try
             {
                 lock (_writeSync)
@@ -418,7 +418,7 @@ namespace HidSharp.Platform.Windows
 
         public override unsafe BleEvent ReadEvent()
         {
-			HandleAcquireIfOpenOrFail();
+            HandleAcquireIfOpenOrFail();
             try
             {
                 IntPtr* handles = stackalloc IntPtr[2];

--- a/HidSharp/Platform/Windows/WinHidDevice.ReportDescriptorReconstructor.cs
+++ b/HidSharp/Platform/Windows/WinHidDevice.ReportDescriptorReconstructor.cs
@@ -100,7 +100,7 @@ namespace HidSharp.Platform.Windows
                     int maxBit = (reportBytes.Length - 1) * 8;
 
                     // Determine the location of all report items.
-                    for (int reportItemIndex = 0; reportItemIndex < reportItemList.Length; reportItemIndex ++)
+                    for (int reportItemIndex = 0; reportItemIndex < reportItemList.Length; reportItemIndex++)
                     {
                         var reportItem = reportItemList[reportItemIndex];
 
@@ -153,7 +153,7 @@ namespace HidSharp.Platform.Windows
                             else
                             {
                                 throw new NotImplementedException();
-                            }                            
+                            }
                         }
                         else if (dataIndexCount == 1)
                         {
@@ -251,7 +251,7 @@ namespace HidSharp.Platform.Windows
             {
                 int countToCheck = Math.Min(_currentNodes.Count, newNodes.Count);
                 int sharedCount;
-                for (sharedCount = 0; sharedCount < countToCheck;  sharedCount++)
+                for (sharedCount = 0; sharedCount < countToCheck; sharedCount++)
                 {
                     if (_currentNodes[sharedCount] != newNodes[sharedCount]) { break; }
                 }
@@ -301,7 +301,7 @@ namespace HidSharp.Platform.Windows
                 {
                     if (NativeMethods.HidP_GetValueCaps(reportType, values, ref count, _preparsed) != NativeMethods.HIDP_STATUS_SUCCESS || count != valueCount) { throw new NotImplementedException(); }
                 }
-                
+
                 caps.Items = buttons.Select(b => new ItemCaps() { Button = true, Item = b })
                     .Concat(values.Select(v => new ItemCaps() { Button = false, Item = v }))
                     .ToArray();

--- a/HidSharp/Platform/Windows/WinHidManager.cs
+++ b/HidSharp/Platform/Windows/WinHidManager.cs
@@ -237,7 +237,7 @@ namespace HidSharp.Platform.Windows
             GC.KeepAlive(windowProc);
         }
 
-        static IntPtr  RegisterDeviceNotification(IntPtr hwnd, Guid guid)
+        static IntPtr RegisterDeviceNotification(IntPtr hwnd, Guid guid)
         {
             var notifyFilter = new NativeMethods.DEV_BROADCAST_DEVICEINTERFACE()
             {
@@ -329,7 +329,7 @@ namespace HidSharp.Platform.Windows
                         // For now, this doesn't raise the DeviceList Changed event. It only seems to occur at connection.
                     }
                 }
-                
+
                 return (IntPtr)1;
             }
 
@@ -369,7 +369,8 @@ namespace HidSharp.Platform.Windows
 
                             switch (NativeMethods.WaitForMultipleObjects(2, handles, false, uint.MaxValue))
                             {
-                                case NativeMethods.WAIT_OBJECT_0: default:
+                                case NativeMethods.WAIT_OBJECT_0:
+                                default:
                                     return;
 
                                 case NativeMethods.WAIT_OBJECT_1:

--- a/HidSharp/Platform/Windows/WinHidStream.cs
+++ b/HidSharp/Platform/Windows/WinHidStream.cs
@@ -36,7 +36,7 @@ namespace HidSharp.Platform.Windows
 
         ~WinHidStream()
         {
-			Close();
+            Close();
             NativeMethods.CloseHandle(_closeEventHandle);
         }
 
@@ -55,43 +55,43 @@ namespace HidSharp.Platform.Windows
                 throw new IOException("Failed to set input buffers.", new Win32Exception());
             }
 
-			_handle = handle;
-			HandleInitAndOpen();
+            _handle = handle;
+            HandleInitAndOpen();
         }
 
         protected override void Dispose(bool disposing)
         {
-			if (!HandleClose()) { return; }
+            if (!HandleClose()) { return; }
 
-			NativeMethods.SetEvent(_closeEventHandle);
-			HandleRelease();
+            NativeMethods.SetEvent(_closeEventHandle);
+            HandleRelease();
 
             base.Dispose(disposing);
-		}
+        }
 
-		internal override void HandleFree()
-		{
-			NativeMethods.CloseHandle(ref _handle);
-			NativeMethods.CloseHandle(ref _closeEventHandle);
-		}
+        internal override void HandleFree()
+        {
+            NativeMethods.CloseHandle(ref _handle);
+            NativeMethods.CloseHandle(ref _closeEventHandle);
+        }
 
         public unsafe override void GetFeature(byte[] buffer, int offset, int count)
         {
             Throw.If.OutOfRange(buffer, offset, count);
 
-			HandleAcquireIfOpenOrFail();
-			try
-			{
-	            fixed (byte* ptr = buffer)
-	            {
-	                if (!NativeMethods.HidD_GetFeature(_handle, ptr + offset, count))
-	                    { throw new IOException("GetFeature failed.", new Win32Exception()); }
-	            }
-			}
-			finally
-			{
-				HandleRelease();
-			}
+            HandleAcquireIfOpenOrFail();
+            try
+            {
+                fixed (byte* ptr = buffer)
+                {
+                    if (!NativeMethods.HidD_GetFeature(_handle, ptr + offset, count))
+                    { throw new IOException("GetFeature failed.", new Win32Exception()); }
+                }
+            }
+            finally
+            {
+                HandleRelease();
+            }
         }
 
         // Buffer needs to be big enough for the largest report, plus a byte
@@ -101,17 +101,17 @@ namespace HidSharp.Platform.Windows
             Throw.If.OutOfRange(buffer, offset, count); uint bytesTransferred;
             IntPtr @event = NativeMethods.CreateManualResetEventOrThrow();
 
-			HandleAcquireIfOpenOrFail();
+            HandleAcquireIfOpenOrFail();
             try
             {
-				lock (_readSync)
-				{
-	                int minIn = Device.GetMaxInputReportLength();
+                lock (_readSync)
+                {
+                    int minIn = Device.GetMaxInputReportLength();
                     if (minIn <= 0) { throw new IOException("Can't read from this device."); }
                     if (_readBuffer == null || _readBuffer.Length < Math.Max(count, minIn)) { Array.Resize(ref _readBuffer, Math.Max(count, minIn)); }
 
-	                fixed (byte* ptr = _readBuffer)
-	                {
+                    fixed (byte* ptr = _readBuffer)
+                    {
                         var overlapped = stackalloc NativeOverlapped[1];
                         overlapped[0].EventHandle = @event;
 
@@ -119,15 +119,15 @@ namespace HidSharp.Platform.Windows
                             NativeMethods.ReadFile(_handle, ptr, Math.Max(count, minIn), IntPtr.Zero, overlapped),
                             overlapped, out bytesTransferred);
 
-	                    if (count > (int)bytesTransferred) { count = (int)bytesTransferred; }
-	                    Array.Copy(_readBuffer, 0, buffer, offset, count);
-	                    return count;
-	                }
-				}
+                        if (count > (int)bytesTransferred) { count = (int)bytesTransferred; }
+                        Array.Copy(_readBuffer, 0, buffer, offset, count);
+                        return count;
+                    }
+                }
             }
             finally
             {
-				HandleRelease();
+                HandleRelease();
                 NativeMethods.CloseHandle(@event);
             }
         }
@@ -136,19 +136,19 @@ namespace HidSharp.Platform.Windows
         {
             Throw.If.OutOfRange(buffer, offset, count);
 
-			HandleAcquireIfOpenOrFail();
-			try
-			{
-	            fixed (byte* ptr = buffer)
-	            {
-	                if (!NativeMethods.HidD_SetFeature(_handle, ptr + offset, count))
-	                    { throw new IOException("SetFeature failed.", new Win32Exception()); }
-	            }
-			}
-			finally
-			{
-				HandleRelease();
-			}
+            HandleAcquireIfOpenOrFail();
+            try
+            {
+                fixed (byte* ptr = buffer)
+                {
+                    if (!NativeMethods.HidD_SetFeature(_handle, ptr + offset, count))
+                    { throw new IOException("SetFeature failed.", new Win32Exception()); }
+                }
+            }
+            finally
+            {
+                HandleRelease();
+            }
         }
 
         public unsafe override void Write(byte[] buffer, int offset, int count)
@@ -156,15 +156,15 @@ namespace HidSharp.Platform.Windows
             Throw.If.OutOfRange(buffer, offset, count); uint bytesTransferred;
             IntPtr @event = NativeMethods.CreateManualResetEventOrThrow();
 
-			HandleAcquireIfOpenOrFail();
+            HandleAcquireIfOpenOrFail();
             try
             {
-				lock (_writeSync)
-				{
-	                int minOut = Device.GetMaxOutputReportLength();
+                lock (_writeSync)
+                {
+                    int minOut = Device.GetMaxOutputReportLength();
                     if (minOut <= 0) { throw new IOException("Can't write to this device."); }
                     if (_writeBuffer == null || _writeBuffer.Length < Math.Max(count, minOut)) { Array.Resize(ref _writeBuffer, Math.Max(count, minOut)); }
-	                Array.Copy(buffer, offset, _writeBuffer, 0, count);
+                    Array.Copy(buffer, offset, _writeBuffer, 0, count);
 
                     if (count < minOut)
                     {
@@ -172,25 +172,25 @@ namespace HidSharp.Platform.Windows
                         count = minOut;
                     }
 
-	                fixed (byte* ptr = _writeBuffer)
-	                {
-	                    int offset0 = 0;
-	                    while (count > 0)
-	                    {
+                    fixed (byte* ptr = _writeBuffer)
+                    {
+                        int offset0 = 0;
+                        while (count > 0)
+                        {
                             NativeOverlapped overlapped = default;
                             overlapped.EventHandle = @event;
 
                             NativeMethods.OverlappedOperation(_handle, @event, WriteTimeout, _closeEventHandle,
-	                            NativeMethods.WriteFile(_handle, ptr + offset0, Math.Min(minOut, count), IntPtr.Zero, &overlapped),
-	                            &overlapped, out bytesTransferred);
-	                        count -= (int)bytesTransferred; offset0 += (int)bytesTransferred;
-	                    }
-	                }
-				}
+                                NativeMethods.WriteFile(_handle, ptr + offset0, Math.Min(minOut, count), IntPtr.Zero, &overlapped),
+                                &overlapped, out bytesTransferred);
+                            count -= (int)bytesTransferred; offset0 += (int)bytesTransferred;
+                        }
+                    }
+                }
             }
             finally
             {
-				HandleRelease();
+                HandleRelease();
                 NativeMethods.CloseHandle(@event);
             }
         }

--- a/HidSharp/Reports/DataItem.cs
+++ b/HidSharp/Reports/DataItem.cs
@@ -54,7 +54,7 @@ namespace HidSharp.Reports
             uint value = 0; int totalBits = Math.Min(ElementBits, 32);
             bitOffset += elementIndex * ElementBits;
 
-            for (int i = 0; i < totalBits; i++, bitOffset ++)
+            for (int i = 0; i < totalBits; i++, bitOffset++)
             {
                 int byteStart = bitOffset >> 3; byte bitStart = (byte)(1u << (bitOffset & 7));
                 value |= (buffer[byteStart] & bitStart) != 0 ? (1u << i) : 0;

--- a/HidSharp/Reports/Encodings/EncodedItem.cs
+++ b/HidSharp/Reports/Encodings/EncodedItem.cs
@@ -156,13 +156,30 @@ namespace HidSharp.Reports.Encodings
             set
             {
                 if (value == 0)
-                    { DataValue = (uint)value; }
+                {
+                    DataValue = (uint)value;
+                }
                 else if (value >= sbyte.MinValue && value <= sbyte.MaxValue)
-                    { DataValue = (uint)(sbyte)value; if (value < 0) { Data.Add(0); } }
+                {
+                    DataValue = (uint)(sbyte)value;
+                    if (value < 0)
+                    {
+                        Data.Add(0);
+                    }
+                }
                 else if (value >= short.MinValue && value <= short.MaxValue)
-                    { DataValue = (uint)(short)value; if (value < 0) { Data.Add(0); Data.Add(0); } }
+                {
+                    DataValue = (uint)(short)value;
+                    if (value < 0)
+                    {
+                        Data.Add(0);
+                        Data.Add(0);
+                    }
+                }
                 else
-                    { DataValue = (uint)value; }
+                {
+                    DataValue = (uint)value;
+                }
             }
         }
 

--- a/HidSharp/Reports/IndexList.cs
+++ b/HidSharp/Reports/IndexList.cs
@@ -28,7 +28,7 @@ namespace HidSharp.Reports
 
         public override bool TryGetIndexFromValue(uint value, out int index)
         {
-            for (int i = 0; i < Indices.Count; i ++)
+            for (int i = 0; i < Indices.Count; i++)
             {
                 foreach (uint thisValue in Indices[i])
                 {

--- a/HidSharp/Reports/IndexRange.cs
+++ b/HidSharp/Reports/IndexRange.cs
@@ -23,7 +23,7 @@ namespace HidSharp.Reports
     {
         public IndexRange()
         {
-            
+
         }
 
         public IndexRange(uint minimum, uint maximum)

--- a/HidSharp/Reports/Input/DeviceItemInputParser.cs
+++ b/HidSharp/Reports/Input/DeviceItemInputParser.cs
@@ -58,7 +58,7 @@ namespace HidSharp.Reports.Input
 
                 foreach (var dataItem in inputReport.DataItems)
                 {
-                    int elementCount = dataItem.ElementCount; 
+                    int elementCount = dataItem.ElementCount;
                     var usages = dataItem.Usages;
                     int usageCount = usages.Count;
 

--- a/HidSharp/Reports/Report.cs
+++ b/HidSharp/Reports/Report.cs
@@ -64,7 +64,7 @@ namespace HidSharp.Reports
 
             var dataItems = DataItems;
             int dataItemCount = dataItems.Count;
-            for (int indexOfDataItem = 0; indexOfDataItem < dataItemCount; indexOfDataItem ++)
+            for (int indexOfDataItem = 0; indexOfDataItem < dataItemCount; indexOfDataItem++)
             {
                 var dataItem = dataItems[indexOfDataItem];
                 callback(buffer, bitOffset, dataItem, indexOfDataItem);

--- a/HidSharp/Reports/Units/Unit.cs
+++ b/HidSharp/Reports/Units/Unit.cs
@@ -86,7 +86,9 @@ namespace HidSharp.Reports.Units
         public static uint EncodeExponent(int value)
         {
             if (value < -8 || value > 7)
-                { throw new ArgumentOutOfRangeException("value", "Exponent range is [-8, 7]."); }
+            {
+                throw new ArgumentOutOfRangeException("value", "Exponent range is [-8, 7].");
+            }
             return (uint)(value < 0 ? value + 16 : value);
         }
 

--- a/HidSharp/SerialSettings.cs
+++ b/HidSharp/SerialSettings.cs
@@ -23,7 +23,10 @@ namespace HidSharp
     {
         public static readonly SerialSettings Default = new SerialSettings()
         {
-            BaudRate = 9600, DataBits = 8, Parity = SerialParity.None, StopBits = 1
+            BaudRate = 9600,
+            DataBits = 8,
+            Parity = SerialParity.None,
+            StopBits = 1
         };
 
         public int BaudRate;
@@ -38,7 +41,7 @@ namespace HidSharp
             lock (@lock)
             {
                 if (BaudRate == baudRate) { return; }
-//Console.WriteLine(string.Format("Baud {0} -> {1}", BaudRate, baudRate));
+                //Console.WriteLine(string.Format("Baud {0} -> {1}", BaudRate, baudRate));
                 BaudRate = baudRate; settingsChanged = true;
             }
         }
@@ -50,7 +53,7 @@ namespace HidSharp
             lock (@lock)
             {
                 if (DataBits == dataBits) { return; }
-//Console.WriteLine(string.Format("Data Bits {0} -> {1}", DataBits, dataBits));
+                //Console.WriteLine(string.Format("Data Bits {0} -> {1}", DataBits, dataBits));
                 DataBits = dataBits; settingsChanged = true;
             }
         }
@@ -60,7 +63,7 @@ namespace HidSharp
             lock (@lock)
             {
                 if (Parity == parity) { return; }
-//Console.WriteLine(string.Format("Parity {0} -> {1}", Parity, parity));
+                //Console.WriteLine(string.Format("Parity {0} -> {1}", Parity, parity));
                 Parity = parity; settingsChanged = true;
             }
         }
@@ -72,7 +75,7 @@ namespace HidSharp
             lock (@lock)
             {
                 if (StopBits == stopBits) { return; }
-//Console.WriteLine(string.Format("Stop Bits {0} -> {1}", StopBits, stopBits));
+                //Console.WriteLine(string.Format("Stop Bits {0} -> {1}", StopBits, stopBits));
                 StopBits = stopBits; settingsChanged = true;
             }
         }


### PR DESCRIPTION
There are some code changes that isn't linting, but they shouldn't affect code behavior.

2f06b6e087884a095518e32df01490f637ca6c6a - Update creation of SHA256 hashes
ba027f47aa37aacc62261be3d7259a386625c8c8 - Fix comparison of IntPtr/nint to null
66e680a52993b7aa5905c005b2d0b3938101e47a - Fix possible stackoverflow
ee20a417cc4e0e34d9c5d0ddd706eef42cb5394f - Remove unneeded preview language feature flag