### PR TITLE
macos: Support devices with I/O Registry paths longer than 512 characters

### DIFF
--- a/HidSharp/Platform/MacOS/MacHidDevice.cs
+++ b/HidSharp/Platform/MacOS/MacHidDevice.cs
@@ -32,18 +32,18 @@ namespace HidSharp.Platform.MacOS
         int _maxInput, _maxOutput, _maxFeature;
         bool _reportsUseID;
         byte[] _reportDescriptor;
-        NativeMethods.io_string_t _path;
+        string _path;
 
         MacHidDevice()
         {
 
         }
 
-        internal static MacHidDevice TryCreate(NativeMethods.io_string_t path)
+        internal static MacHidDevice TryCreate(string path)
         {
             var d = new MacHidDevice() { _path = path };
 
-            var service = NativeMethods.IORegistryEntryFromPath(0, ref path).ToIOObject();
+            var service = NativeMethods.IORegistryEntryCopyFromPath(0, path).ToIOObject();
             if (!service.IsSet) { return null; }
 
             using (service)
@@ -297,7 +297,8 @@ namespace HidSharp.Platform.MacOS
             }
 
             // Determine USB device from HID path
-            var hidEntry = NativeMethods.IORegistryEntryFromPath(masterPort, ref _path).ToIOObject();
+            var hidEntry = NativeMethods.IORegistryEntryCopyFromPath(masterPort, _path).ToIOObject();
+
             int deviceEntry = 0;
 
             if (hidEntry.IsSet)
@@ -319,7 +320,7 @@ namespace HidSharp.Platform.MacOS
 
         public override string DevicePath
         {
-            get { return _path.ToString(); }
+            get { return _path; }
         }
 
         public override int VendorID

--- a/HidSharp/Platform/MacOS/MacHidManager.cs
+++ b/HidSharp/Platform/MacOS/MacHidManager.cs
@@ -69,7 +69,7 @@ namespace HidSharp.Platform.MacOS
 
         object[] GetDeviceKeys(string kind)
         {
-            var paths = new List<NativeMethods.io_string_t>();
+            var paths = new List<string>();
 
             var matching = NativeMethods.IOServiceMatching(kind).ToCFType(); // Consumed by IOServiceGetMatchingServices, so DON'T Dispose().
             if (matching.IsSet)
@@ -85,10 +85,12 @@ namespace HidSharp.Platform.MacOS
                             {
                                 if (!handle.IsSet) { break; }
 
-                                NativeMethods.io_string_t path;
-                                if (NativeMethods.IOReturn.Success == NativeMethods.IORegistryEntryGetPath(handle, "IOService", out path))
+                                using (var cfPath = NativeMethods.IORegistryEntryCopyPath(handle, "IOService").ToCFType())
                                 {
-                                    paths.Add(path);
+                                    if (cfPath.IsSet)
+                                    {
+                                        paths.Add(NativeMethods.CFStringGetCharacters(cfPath));
+                                    }
                                 }
                             }
                         }
@@ -121,13 +123,13 @@ namespace HidSharp.Platform.MacOS
 
         protected override bool TryCreateHidDevice(object key, out Device device)
         {
-            device = MacHidDevice.TryCreate((NativeMethods.io_string_t)key);
+            device = MacHidDevice.TryCreate((string)key);
             return device != null;
         }
 
         protected override bool TryCreateSerialDevice(object key, out Device device)
         {
-            device = MacSerialDevice.TryCreate((NativeMethods.io_string_t)key);
+            device = MacSerialDevice.TryCreate((string)key);
             return device != null;
         }
 

--- a/HidSharp/Platform/MacOS/MacHidStream.cs
+++ b/HidSharp/Platform/MacOS/MacHidStream.cs
@@ -44,13 +44,12 @@ namespace HidSharp.Platform.MacOS
             _writeThread = new Thread(WriteThread) { IsBackground = true, Name = "HID Writer" };
         }
 
-        internal void Init(NativeMethods.io_string_t path)
+        internal void Init(string path)
         {
             IntPtr handle; int retryCount = 0, maxRetries = 10;
             while (true)
             {
-                var newPath = path.Clone();
-                using (var service = NativeMethods.IORegistryEntryFromPath(0, ref newPath).ToIOObject())
+                using (var service = NativeMethods.IORegistryEntryCopyFromPath(0, path).ToIOObject())
                 {
                     string error;
 
@@ -65,16 +64,16 @@ namespace HidSharp.Platform.MacOS
                             NativeMethods.CFRelease(handle);
 
                             // TODO: Only count up if IOReturn is ExclusiveAccess or Offline.
-                            error = string.Format("Unable to open HID class device (error {1}): {0}", newPath.ToString(), ret);
+                            error = string.Format("Unable to open HID class device (error {1}): {0}", path, ret);
                         }
                         else
                         {
-                            error = string.Format("HID class device not found: {0}", newPath.ToString());
+                            error = string.Format("HID class device not found: {0}", path);
                         }
                     }
                     else
                     {
-                        error = string.Format("HID class device path not found: {0}", newPath.ToString());
+                        error = string.Format("HID class device path not found: {0}", path);
                     }
 
                     if (++retryCount == maxRetries)

--- a/HidSharp/Platform/MacOS/MacSerialDevice.cs
+++ b/HidSharp/Platform/MacOS/MacSerialDevice.cs
@@ -21,7 +21,7 @@ namespace HidSharp.Platform.MacOS
 {
     sealed class MacSerialDevice : SerialDevice
     {
-        NativeMethods.io_string_t _path;
+        string _path;
         string _fileSystemName;
 
         protected override DeviceStream OpenDeviceDirectly(OpenConfiguration openConfig)
@@ -29,11 +29,11 @@ namespace HidSharp.Platform.MacOS
             return new MacSerialStream(this);
         }
 
-        internal static MacSerialDevice TryCreate(NativeMethods.io_string_t path)
+        internal static MacSerialDevice TryCreate(string path)
         {
             var d = new MacSerialDevice() { _path = path };
 
-            var handle = NativeMethods.IORegistryEntryFromPath(0, ref path).ToIOObject();
+            var handle = NativeMethods.IORegistryEntryCopyFromPath(0, path).ToIOObject();
             if (!handle.IsSet) { return null; }
 
             using (handle)
@@ -57,7 +57,7 @@ namespace HidSharp.Platform.MacOS
 
         public override string DevicePath
         {
-            get { return _path.ToString(); }
+            get { return _path; }
         }
 
         public override bool CanOpen => true;

--- a/HidSharp/Platform/MacOS/NativeMethods.cs
+++ b/HidSharp/Platform/MacOS/NativeMethods.cs
@@ -724,6 +724,25 @@ namespace HidSharp.Platform.MacOS
             }
         }
 
+        [DllImport(IOKit, EntryPoint = "IORegistryEntryCopyFromPath")]
+        public static extern int IORegistryEntryCopyFromPath(uint masterPort, IntPtr path);
+
+        public static int IORegistryEntryCopyFromPath(uint masterPort, string path)
+        {
+            var cfPath = CFStringCreateWithCharacters(path);
+            try
+            {
+                return IORegistryEntryCopyFromPath(masterPort, cfPath);
+            }
+            finally
+            {
+                if (cfPath != IntPtr.Zero) { CFRelease(cfPath); }
+            }
+        }
+
+        [DllImport(IOKit, EntryPoint = "IORegistryEntryCopyPath")]
+        public static extern IntPtr IORegistryEntryCopyPath(int entry, [MarshalAs(UnmanagedType.LPStr)] string plane);
+
         [DllImport(IOKit, EntryPoint = "IORegistryEntryFromPath")]
         public static extern int IORegistryEntryFromPath(uint masterPort, ref io_string_t path);
 


### PR DESCRIPTION

The original code uses IORegistryEntryGetPath and IORegistryEntryFromPath, which rely on io_string_t buffers limited to 512 characters. Long chains of USB hubs can produce registry paths that exceed this limit, causing failures (e.g., empty paths returned).
This commit switches to IORegistryEntryCopyPath and IORegistryEntryCreateFromPath, which return a dynamically allocated string and support arbitrary path lengths.

see
https://developer.apple.com/documentation/kernel/io_string_t?language=objc https://developer.apple.com/documentation/iokit/1514229-ioregistryentrygetpath?language=objc