### PR TITLE
macOS: fix device rejection for Input (Constant)-only HID interfaces

### DIFF
--- a/HidSharp/Platform/MacOS/MacHidDevice.cs
+++ b/HidSharp/Platform/MacOS/MacHidDevice.cs
@@ -76,17 +76,18 @@ namespace HidSharp.Platform.MacOS
 
                     using (var elementArray = NativeMethods.IOHIDDeviceCopyMatchingElements(device, IntPtr.Zero).ToCFType())
                     {
-                        if (!elementArray.IsSet) { return null; }
-
-                        int elementCount = checked((int)NativeMethods.CFArrayGetCount(elementArray));
-                        for (int elementIndex = 0; elementIndex < elementCount; elementIndex++)
+                        if (elementArray.IsSet)
                         {
-                            var element = NativeMethods.CFArrayGetValueAtIndex(elementArray, (IntPtr)elementIndex);
-                            if (element == IntPtr.Zero) { continue; }
-
-                            if (NativeMethods.IOHIDElementGetReportID(element) != 0)
+                            int elementCount = checked((int)NativeMethods.CFArrayGetCount(elementArray));
+                            for (int elementIndex = 0; elementIndex < elementCount; elementIndex++)
                             {
-                                d._reportsUseID = true;
+                                var element = NativeMethods.CFArrayGetValueAtIndex(elementArray, (IntPtr)elementIndex);
+                                if (element == IntPtr.Zero) { continue; }
+
+                                if (NativeMethods.IOHIDElementGetReportID(element) != 0)
+                                {
+                                    d._reportsUseID = true;
+                                }
                             }
                         }
                     }

--- a/HidSharp/Platform/MacOS/MacHidDevice.cs
+++ b/HidSharp/Platform/MacOS/MacHidDevice.cs
@@ -69,7 +69,7 @@ namespace HidSharp.Platform.MacOS
                 if (d._maxInput == 0 && d._maxOutput == 0 && d._maxFeature == 0) { return null; }
 
                 // Does this device use Report IDs? Let's find out.
-                d._reportsUseID = false; bool hasInput = false, hasOutput = false, hasFeature = false;
+                d._reportsUseID = false;
                 using (var device = NativeMethods.IOHIDDeviceCreate(IntPtr.Zero, service).ToCFType())
                 {
                     if (!device.IsSet) { return null; }
@@ -83,22 +83,6 @@ namespace HidSharp.Platform.MacOS
                         {
                             var element = NativeMethods.CFArrayGetValueAtIndex(elementArray, (IntPtr)elementIndex);
                             if (element == IntPtr.Zero) { continue; }
-
-                            var elementType = NativeMethods.IOHIDElementGetType(element);
-                            switch (elementType)
-                            {
-                                case NativeMethods.IOHIDElementType.InputMisc:
-                                case NativeMethods.IOHIDElementType.InputButton:
-                                case NativeMethods.IOHIDElementType.InputAxis:
-                                case NativeMethods.IOHIDElementType.InputScanCodes:
-                                    hasInput = true; break;
-
-                                case NativeMethods.IOHIDElementType.Output:
-                                    hasOutput = true; break;
-
-                                case NativeMethods.IOHIDElementType.Feature:
-                                    hasFeature = true; break;
-                            }
 
                             if (NativeMethods.IOHIDElementGetReportID(element) != 0)
                             {
@@ -116,9 +100,6 @@ namespace HidSharp.Platform.MacOS
                     if (d._maxFeature != 0) { d._maxFeature++; }
                 }
 
-                if (!hasInput) { d._maxInput = 0; }
-                if (!hasOutput) { d._maxOutput = 0; }
-                if (!hasFeature) { d._maxFeature = 0; }
             }
 
             return d;


### PR DESCRIPTION
Changes:
I removed the element type validation that zeroed out max report sizes when no variable IOHIDElements were found, and changed the null element array check to skip the loop instead of rejecting the device.

Why?
Because the loop only exists to detect report ID usage, and devices with only Constant fields have no enumerable elements. Neither Windows nor Linux does this type of filtering. Those platforms trust the OS reported sizes unconditionally, so should macOS.

I tested this built locally with OTD and the WirelessAddonKit plugin, and it works well.

This helps an issue that were macOS only. (In the WirelessAddonKit plugin)
- HIDSharp was suppressing a 32byte Constant stream that contained battery reports (available on both Windows and Linux).