### PR TITLE
Fix DecodeExponent rejecting byte-encoded UnitExponent values

### DIFF
--- a/HidSharp/Reports/Units/Unit.cs
+++ b/HidSharp/Reports/Units/Unit.cs
@@ -63,12 +63,15 @@ namespace HidSharp.Reports.Units
 
         /// <summary>
         /// Decodes an encoded HID unit exponent.
+        /// The HID spec defines UnitExponent as a 4-bit signed value (nibble),
+        /// but some devices encode it as a signed byte (e.g. 0xFD for -3).
+        /// Masking to 4 bits handles both encodings correctly.
         /// </summary>
         /// <param name="value">The encoded exponent.</param>
         /// <returns>The exponent.</returns>
         public static int DecodeExponent(uint value)
         {
-            if (value > 15) { throw new ArgumentOutOfRangeException("value", "Value range is [0, 15]."); }
+            value &= 0xF;
             return value >= 8 ? (int)value - 16 : (int)value;
         }
 


### PR DESCRIPTION
## Summary

`Unit.DecodeExponent()` throws `ArgumentOutOfRangeException` when `UnitExponent` is encoded as a signed byte (e.g. `0xFD` for -3) instead of a 4-bit nibble. This prevents `TryParseReportDescriptor` from succeeding, which in turn causes `GetMaxInputReportLength()` to throw and `TryOpen()` to fail.

The fix masks the value to 4 bits before decoding. This handles both encodings correctly:
- Nibble `0x0D` → stays `0x0D` → decodes to -3
- Byte `0xFD` → masked to `0x0D` → decodes to -3

## Affected devices

Observed on the Waltop Sirius Battery Free Tablet (`172f:0502`), whose HID descriptor contains:
```
55 FD    ; UnitExponent(-3) encoded as signed byte
55 FE    ; UnitExponent(-2) encoded as signed byte
```

## Change

One line in `HidSharp/Reports/Units/Unit.cs`:

```diff
 public static int DecodeExponent(uint value)
 {
-    if (value > 15) { throw new ArgumentOutOfRangeException("value", "Value range is [0, 15]."); }
+    value &= 0xF;
     return value >= 8 ? (int)value - 16 : (int)value;
 }
```